### PR TITLE
Implement-all-clients-endpoints

### DIFF
--- a/src/API/Clients.php
+++ b/src/API/Clients.php
@@ -82,9 +82,9 @@ class Clients extends AbstractAPI
         if ( count( $missingParameters ) !== 0 ) {
             $missingKeys = implode( ', ', array_keys( $missingParameters ) );
 
-            return [
-                'internal_error' => "Missing required parameter(s): $missingKeys",
-            ];
+            throw new \InvalidArgumentException(
+                "Missing required parameter(s): $missingKeys"
+            );
         }
 
 
@@ -127,9 +127,9 @@ class Clients extends AbstractAPI
         if ( count( $missingParameters ) !== 0 ) {
             $missingKeys = implode( ', ', array_keys( $missingParameters ) );
 
-            return [
-                'internal_error' => "Missing required parameter(s): $missingKeys",
-            ];
+            throw new \InvalidArgumentException(
+                "Missing required parameter(s): $missingKeys"
+            );
         }
 
         $response = $this->client->request(

--- a/src/API/Clients.php
+++ b/src/API/Clients.php
@@ -58,15 +58,11 @@ class Clients extends AbstractAPI
     *
     * @see https://rmp-api.rik.ee/api.html#operation/post-clients
     *
-    * @param array<string, mixed> $requiredParameters required request parameters.
-    * @param array<string, mixed> $parameters additional request parameters.
+    * @param array<string, mixed> $parameters all request parameters.
     *
     * @return mixed
     */
-    public function create(
-        array $requiredParameters,
-        array $parameters = []
-    ): mixed {
+    public function create( array $parameters = [] ): mixed {
 
         $missingParameters = array_diff_key(
             array_flip(
@@ -80,7 +76,7 @@ class Clients extends AbstractAPI
                     'send_invoice_to_accounting_email',
                 ]
             ),
-            $requiredParameters
+            $parameters
         );
 
         if ( count( $missingParameters ) !== 0 ) {
@@ -91,7 +87,7 @@ class Clients extends AbstractAPI
             ];
         }
 
-        return $this->client->request( 'POST', 'clients', [], array_merge( $requiredParameters, $parameters ) );
+        return $this->client->request( 'POST', 'clients', [], $parameters );
     }
 
     /**
@@ -99,8 +95,7 @@ class Clients extends AbstractAPI
     *
     * @see https://rmp-api.rik.ee/api.html#operation/patch-clients_one
     *
-    * @param array<string, mixed> $requiredParameters required request parameters.
-    * @param array<string, mixed> $parameters additional request parameters.
+    * @param array<string, mixed> $parameters all request parameters.
     *
     * @return mixed
     */

--- a/src/API/Clients.php
+++ b/src/API/Clients.php
@@ -94,6 +94,44 @@ class Clients extends AbstractAPI
         return $this->client->request( 'POST', 'clients', [], array_merge( $requiredParameters, $parameters ) );
     }
 
+    /**
+    * Modify one specific client.
+    *
+    * @see https://rmp-api.rik.ee/api.html#operation/patch-clients_one
+    *
+    * @param array<string, mixed> $requiredParameters required request parameters.
+    * @param array<string, mixed> $parameters additional request parameters.
+    *
+    * @return mixed
+    */
+    public function update( int $id, array $parameters ): mixed {
+
+        $missingParameters = array_diff_key(
+            array_flip(
+                [
+                    'is_client',
+                    'is_supplier',
+                    'name',
+                    'cl_code_country',
+                    'is_member',
+                    'send_invoice_to_email',
+                    'send_invoice_to_accounting_email',
+                ]
+            ),
+            $parameters
+        );
+
+        if ( count( $missingParameters ) !== 0 ) {
+            $missingKeys = implode( ', ', array_keys( $missingParameters ) );
+
+            return [
+                'internal_error' => "Missing required parameter(s): $missingKeys",
+            ];
+        }
+
+        return $this->client->request( 'PATCH', 'clients/' . $id, [], $parameters );
+    }
+
      /**
      * Delete one specific Client.
      *

--- a/src/API/Clients.php
+++ b/src/API/Clients.php
@@ -147,4 +147,18 @@ class Clients extends AbstractAPI
 
         return $response;
     }
+
+    /**
+     * Deactivate one specific client.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/patch-clients_one_deactivate
+     *
+     * @param int $id Client identificator.
+     */
+    public function deactivate( int $id ): mixed
+    {
+        $response = $this->client->request( 'PATCH', 'clients/' . $id . '/deactivate' );
+
+        return $response;
+    }
 }

--- a/src/API/Clients.php
+++ b/src/API/Clients.php
@@ -87,7 +87,15 @@ class Clients extends AbstractAPI
             ];
         }
 
-        return $this->client->request( 'POST', 'clients', [], $parameters );
+
+        $response = $this->client->request(
+            'POST',
+            'clients',
+            [],
+            $parameters
+        );
+
+        return $response;
     }
 
     /**

--- a/src/API/Clients.php
+++ b/src/API/Clients.php
@@ -7,9 +7,9 @@ use DateTime;
 class Clients extends AbstractAPI
 {
     /**
-     * Get the clients.
+     * Get all the clients.
      *
-     * @see https://rmp-api.rik.ee/api.html#operation/get-clients e-Financials API
+     * @see https://rmp-api.rik.ee/api.html#operation/get-clients
      *
      * @param int             $page Page of responses to return.
      * @param DateTime|string $modifiedSince Return only objects modified since provided timestamp.
@@ -33,6 +33,22 @@ class Clients extends AbstractAPI
         }
 
         $response = $this->client->request( 'GET', 'clients', $query );
+
+        return $response;
+    }
+
+    /**
+     * Get a client.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/get-clients_one
+     *
+     * @param int $id Client identificator.
+     *
+     * @return mixed
+     */
+    public function get( int $id ): mixed
+    {
+        $response = $this->client->request( 'GET', 'clients/' . $id );
 
         return $response;
     }

--- a/src/API/Clients.php
+++ b/src/API/Clients.php
@@ -161,4 +161,18 @@ class Clients extends AbstractAPI
 
         return $response;
     }
+
+    /**
+     * Deactivate one specific client.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/patch-clients_one_reactivate
+     *
+     * @param int $id Client identificator.
+     */
+    public function reactivate( int $id ): mixed
+    {
+        $response = $this->client->request( 'PATCH', 'clients/' . $id . '/reactivate' );
+
+        return $response;
+    }
 }

--- a/src/API/Clients.php
+++ b/src/API/Clients.php
@@ -124,7 +124,14 @@ class Clients extends AbstractAPI
             ];
         }
 
-        return $this->client->request( 'PATCH', 'clients/' . $id, [], $parameters );
+        $response = $this->client->request(
+            'PATCH',
+            'clients/' . $id,
+            [],
+            $parameters
+        );
+
+        return $response
     }
 
      /**

--- a/src/API/Clients.php
+++ b/src/API/Clients.php
@@ -131,7 +131,7 @@ class Clients extends AbstractAPI
             $parameters
         );
 
-        return $response
+        return $response;
     }
 
      /**

--- a/src/API/Clients.php
+++ b/src/API/Clients.php
@@ -163,7 +163,7 @@ class Clients extends AbstractAPI
     }
 
     /**
-     * Deactivate one specific client.
+     * Reactivate one specific client.
      *
      * @see https://rmp-api.rik.ee/api.html#operation/patch-clients_one_reactivate
      *


### PR DESCRIPTION
**Important change**

Modified `create` method header to only accept one parameter `parameters` that has all the required and non-required key-value pairs. 

**Question about handling errors**

I noticed on your Products endpoints, you are throwing an error, in case there are any missing required parameters. What's the advantage of throwing an error instead of returning the array with error information? Will it make it easier to detect wrong input on the WooCommerce platform later? I'm curious to learn more.

My version

```php
 if ( count( $missingParameters ) !== 0 ) {
            $missingKeys = implode( ', ', array_keys( $missingParameters ) );

            return [
                'internal_error' => "Missing required parameter(s): $missingKeys",
            ];
        }
```
Your version

```php
 if ( count( $missingRequiredParameters ) !== 0 ) {
            $missingKeys = implode( ', ', array_keys( $missingRequiredParameters ) );

            throw new \InvalidArgumentException(
                "Missing required parameter(s): $missingKeys"
            );
        }
```

