### PR TITLE
feat: complete e-arveldaja API client endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,21 @@
-# README
-TODO
+# e-Financials (e-Arveldaja) PHP API Client
+
+PHP client for the [e-Arveldaja / e-Financials REST API](https://abiinfo.rik.ee/node/304/).
+
+API docs: [OpenAPI HTML](https://demo-rmp-api.rik.ee/api.html) · [openapi.yaml](https://demo-rmp-api.rik.ee/openapi.yaml)
+
+## Installation
+
+```bash
+composer require e-financials/php-client
+```
+
+## Authentication
+
+Generate an API key in e-Arveldaja under **Seadistused → Üldised seadistused**. Each request is signed with:
+
+- `X-AUTH-QUERYTIME` — UTC timestamp (`Y-m-d\TH:i:s`)
+- `X-AUTH-KEY` — `{apiKeyPublic}:{BASE64(HMAC-SHA-384("{apiKeyId}:{queryTime}:{path}", apiKeyPassword))}`
 
 ## Example
 
@@ -14,9 +30,35 @@ $client = new Client(
     apiKeyId: 'api_key_id',
     apiKeyPublic: 'api_key_public',
     apiKeyPassword: 'api_key_password',
+    // apiUrl: 'https://demo-rmp-api.rik.ee', // default demo
 );
 
 print_r( $client->clients()->all() );
-print_r( $client->purchaseArticles()->all() );
-print_r( $client->salesArticles()->all() );
+print_r( $client->salesInvoices()->all() );
+print_r( $client->journals()->all() );
+print_r( $client->transactions()->all() );
+print_r( $client->purchaseInvoices()->all() );
+print_r( $client->templates()->all() );
 ```
+
+## Available resources
+
+| Accessor | Endpoints |
+| --- | --- |
+| `clients()` | Clients CRUD, deactivate/reactivate |
+| `products()` | Products CRUD, deactivate/reactivate |
+| `costProfitCentres()` | Cost/profit centres list |
+| `journals()` | Journals CRUD, register/invalidate, files |
+| `invoices()` | Invoice series CRUD, invoice settings |
+| `bank()` | Bank accounts CRUD, VAT info |
+| `accounts()` | Account list |
+| `accountDimensions()` | Account dimension list |
+| `currencies()` | Currency list |
+| `purchaseArticles()` | Purchase article list |
+| `salesArticles()` | Sale article list |
+| `transactions()` | Transactions CRUD, register/invalidate, files |
+| `salesInvoices()` | Sale invoices CRUD, register/invalidate, files, delivery |
+| `purchaseInvoices()` | Purchase invoices CRUD, register/invalidate, files |
+| `templates()` | Sale invoice templates |
+
+Demo API base URL: `https://demo-rmp-api.rik.ee` (version path `/v1`).

--- a/src/API/Invoices.php
+++ b/src/API/Invoices.php
@@ -134,6 +134,22 @@ class Invoices extends AbstractAPI
     }
 
     /**
+     * Delete one specific invoice series of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/delete-invoice_series_one
+     *
+     * @param int $id Invoice series identificator.
+     *
+     * @return mixed
+     */
+    public function delete( int $id ): mixed
+    {
+        $response = $this->client->request( 'DELETE', 'invoice_series/' . $id );
+
+        return $response;
+    }
+
+    /**
      * Retrieve the invoice settings of the specified company.
      *
      * @see https://rmp-api.rik.ee/api.html#operation/get-invoice_info

--- a/src/API/Journals.php
+++ b/src/API/Journals.php
@@ -1,0 +1,287 @@
+<?php
+
+namespace EFinancialsClient\API;
+
+use DateTime;
+
+class Journals extends AbstractAPI
+{
+    /**
+     * Retrieve the journal entry list of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/get-journals
+     *
+     * @param int             $page Page of responses to return.
+     * @param DateTime|string $modifiedSince Return only objects modified since provided timestamp.
+     * @param DateTime|string $startDate Effective date on given date or later.
+     * @param DateTime|string $endDate Effective date on given date or before.
+     *
+     * @return mixed
+     */
+    public function all(
+        int $page = 1,
+        DateTime|string $modifiedSince = '',
+        DateTime|string $startDate = '',
+        DateTime|string $endDate = '',
+    ): mixed {
+        $query = [];
+
+        if ( $page !== 1 ) {
+            $query['page'] = $page;
+        }
+
+        if ( $modifiedSince !== '' ) {
+            $query['modified_since'] = ( $modifiedSince instanceof DateTime )
+                ? $modifiedSince->format( \DateTimeInterface::ATOM )
+                : $modifiedSince;
+        }
+
+        if ( $startDate !== '' ) {
+            $query['start_date'] = ( $startDate instanceof DateTime )
+                ? $startDate->format( 'Y-m-d' )
+                : $startDate;
+        }
+
+        if ( $endDate !== '' ) {
+            $query['end_date'] = ( $endDate instanceof DateTime )
+                ? $endDate->format( 'Y-m-d' )
+                : $endDate;
+        }
+
+        $response = $this->client->request( 'GET', 'journals', $query );
+
+        return $response;
+    }
+
+    /**
+     * Retrieve one specific journal entry of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/get-journals_one
+     *
+     * @param int $id Journal entry identificator.
+     *
+     * @return mixed
+     */
+    public function get( int $id ): mixed
+    {
+        $response = $this->client->request( 'GET', 'journals/' . $id );
+
+        return $response;
+    }
+
+    /**
+     * Create a new journal entry of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/post-journals
+     *
+     * @param array<string,mixed>|array{
+     *   "effective_date": "2014-05-31",
+     *   "postings": array,
+     *   "title": string,
+     *   "clients_id": int,
+     *   "cl_currencies_id": "EUR",
+     *   "document_number": string,
+     * } $parameters
+     *
+     * @return mixed
+     */
+    public function create( array $parameters = [] ): mixed
+    {
+        $missingRequiredParameters = array_diff_key(
+            array_flip(
+                [
+                    'effective_date',
+                    'postings',
+                ]
+            ),
+            $parameters
+        );
+
+        if ( count( $missingRequiredParameters ) !== 0 ) {
+            $missingKeys = implode( ', ', array_keys( $missingRequiredParameters ) );
+
+            throw new \InvalidArgumentException(
+                "Missing required parameter(s): $missingKeys"
+            );
+        }
+
+        $response = $this->client->request(
+            'POST',
+            'journals',
+            [],
+            $parameters
+        );
+
+        return $response;
+    }
+
+    /**
+     * Modify one specific journal entry of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/patch-journals_one
+     *
+     * @param int $id Journal entry identificator.
+     * @param array<string,mixed>|array{
+     *   "effective_date": "2014-05-31",
+     *   "postings": array,
+     *   "title": string,
+     *   "clients_id": int,
+     *   "cl_currencies_id": "EUR",
+     *   "document_number": string,
+     * } $parameters
+     *
+     * @return mixed
+     */
+    public function update( int $id, array $parameters ): mixed
+    {
+        $missingRequiredParameters = array_diff_key(
+            array_flip(
+                [
+                    'effective_date',
+                    'postings',
+                ]
+            ),
+            $parameters
+        );
+
+        if ( count( $missingRequiredParameters ) !== 0 ) {
+            $missingKeys = implode( ', ', array_keys( $missingRequiredParameters ) );
+
+            throw new \InvalidArgumentException(
+                "Missing required parameter(s): $missingKeys"
+            );
+        }
+
+        $response = $this->client->request(
+            'PATCH',
+            'journals/' . $id,
+            [],
+            $parameters
+        );
+
+        return $response;
+    }
+
+    /**
+     * Delete one specific journal entry of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/delete-journals_one
+     *
+     * @param int $id Journal entry identificator.
+     *
+     * @return mixed
+     */
+    public function delete( int $id ): mixed
+    {
+        $response = $this->client->request( 'DELETE', 'journals/' . $id );
+
+        return $response;
+    }
+
+    /**
+     * Register one specific journal entry of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/patch-journals_one_register
+     *
+     * @param int $id Journal entry identificator.
+     *
+     * @return mixed
+     */
+    public function register( int $id ): mixed
+    {
+        $response = $this->client->request( 'PATCH', 'journals/' . $id . '/register' );
+
+        return $response;
+    }
+
+    /**
+     * Invalidate one specific journal entry of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/patch-journals_one_invalidate
+     *
+     * @param int $id Journal entry identificator.
+     *
+     * @return mixed
+     */
+    public function invalidate( int $id ): mixed
+    {
+        $response = $this->client->request( 'PATCH', 'journals/' . $id . '/invalidate' );
+
+        return $response;
+    }
+
+    /**
+     * Retrieve the document related to a journal entry of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/get-journals_one_document_user
+     *
+     * @param int $id Journal entry identificator.
+     *
+     * @return mixed
+     */
+    public function getFile( int $id ): mixed
+    {
+        $response = $this->client->request( 'GET', 'journals/' . $id . '/document_user' );
+
+        return $response;
+    }
+
+    /**
+     * Update the document related to a journal entry of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/put-journals_one_document_user
+     *
+     * @param int $id Journal entry identificator.
+     * @param array<string,mixed>|array{
+     *   "name": string,
+     *   "contents": string,
+     * } $parameters Base64-encoded file payload.
+     *
+     * @return mixed
+     */
+    public function updateFile( int $id, array $parameters ): mixed
+    {
+        $missingRequiredParameters = array_diff_key(
+            array_flip(
+                [
+                    'name',
+                    'contents',
+                ]
+            ),
+            $parameters
+        );
+
+        if ( count( $missingRequiredParameters ) !== 0 ) {
+            $missingKeys = implode( ', ', array_keys( $missingRequiredParameters ) );
+
+            throw new \InvalidArgumentException(
+                "Missing required parameter(s): $missingKeys"
+            );
+        }
+
+        $response = $this->client->request(
+            'PUT',
+            'journals/' . $id . '/document_user',
+            [],
+            $parameters
+        );
+
+        return $response;
+    }
+
+    /**
+     * Delete the document related to a journal entry of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/delete-journals_one_document_user
+     *
+     * @param int $id Journal entry identificator.
+     *
+     * @return mixed
+     */
+    public function deleteFile( int $id ): mixed
+    {
+        $response = $this->client->request( 'DELETE', 'journals/' . $id . '/document_user' );
+
+        return $response;
+    }
+}

--- a/src/API/PurchaseInvoices.php
+++ b/src/API/PurchaseInvoices.php
@@ -1,0 +1,317 @@
+<?php
+
+namespace EFinancialsClient\API;
+
+use DateTime;
+
+class PurchaseInvoices extends AbstractAPI
+{
+    /**
+     * Retrieve the purchase invoice list of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/get-purchase_invoices
+     *
+     * @param int             $page Page of responses to return.
+     * @param DateTime|string $modifiedSince Return only objects modified since provided timestamp.
+     * @param DateTime|string $startDate Object created on given date or later.
+     * @param DateTime|string $endDate Object created on given date or before.
+     * @param string          $status Object status.
+     * @param string          $paymentStatus Object payment status.
+     * @param int|null        $clientsId Supplier identificator.
+     *
+     * @return mixed
+     */
+    public function all(
+        int $page = 1,
+        DateTime|string $modifiedSince = '',
+        DateTime|string $startDate = '',
+        DateTime|string $endDate = '',
+        string $status = '',
+        string $paymentStatus = '',
+        ?int $clientsId = null,
+    ): mixed {
+        $query = [];
+
+        if ( $page !== 1 ) {
+            $query['page'] = $page;
+        }
+
+        if ( $modifiedSince !== '' ) {
+            $query['modified_since'] = ( $modifiedSince instanceof DateTime )
+                ? $modifiedSince->format( \DateTimeInterface::ATOM )
+                : $modifiedSince;
+        }
+
+        if ( $startDate !== '' ) {
+            $query['start_date'] = ( $startDate instanceof DateTime )
+                ? $startDate->format( 'Y-m-d' )
+                : $startDate;
+        }
+
+        if ( $endDate !== '' ) {
+            $query['end_date'] = ( $endDate instanceof DateTime )
+                ? $endDate->format( 'Y-m-d' )
+                : $endDate;
+        }
+
+        if ( $status !== '' ) {
+            $query['status'] = $status;
+        }
+
+        if ( $paymentStatus !== '' ) {
+            $query['payment_status'] = $paymentStatus;
+        }
+
+        if ( $clientsId !== null ) {
+            $query['clients_id'] = $clientsId;
+        }
+
+        $response = $this->client->request( 'GET', 'purchase_invoices', $query );
+
+        return $response;
+    }
+
+    /**
+     * Retrieve one specific purchase invoice of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/get-purchase_invoices_one
+     *
+     * @param int $id Purchase invoice identificator.
+     *
+     * @return mixed
+     */
+    public function get( int $id ): mixed
+    {
+        $response = $this->client->request( 'GET', 'purchase_invoices/' . $id );
+
+        return $response;
+    }
+
+    /**
+     * Create a new purchase invoice of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/post-purchase_invoices
+     *
+     * @param array<string,mixed>|array{
+     *   "clients_id": 803,
+     *   "client_name": string,
+     *   "number": string,
+     *   "create_date": "2017-08-09",
+     *   "journal_date": "2017-08-09",
+     *   "term_days": 0,
+     *   "cl_currencies_id": "EUR"
+     * } $parameters
+     *
+     * @return mixed
+     */
+    public function create( array $parameters = [] ): mixed
+    {
+        $missingRequiredParameters = array_diff_key(
+            array_flip(
+                [
+                    'clients_id',
+                    'client_name',
+                    'number',
+                    'create_date',
+                    'journal_date',
+                    'term_days',
+                    'cl_currencies_id',
+                ]
+            ),
+            $parameters
+        );
+
+        if ( count( $missingRequiredParameters ) !== 0 ) {
+            $missingKeys = implode( ', ', array_keys( $missingRequiredParameters ) );
+
+            throw new \InvalidArgumentException(
+                "Missing required parameter(s): $missingKeys"
+            );
+        }
+
+        $response = $this->client->request(
+            'POST',
+            'purchase_invoices',
+            [],
+            $parameters
+        );
+
+        return $response;
+    }
+
+    /**
+     * Modify one specific purchase invoice of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/patch-purchase_invoices_one
+     *
+     * @param int $id Purchase invoice identificator.
+     * @param array<string,mixed>|array{
+     *   "clients_id": 803,
+     *   "client_name": string,
+     *   "number": string,
+     *   "create_date": "2017-08-09",
+     *   "journal_date": "2017-08-09",
+     *   "term_days": 0,
+     *   "cl_currencies_id": "EUR"
+     * } $parameters
+     *
+     * @return mixed
+     */
+    public function update( int $id, array $parameters ): mixed
+    {
+        $missingRequiredParameters = array_diff_key(
+            array_flip(
+                [
+                    'clients_id',
+                    'client_name',
+                    'number',
+                    'create_date',
+                    'journal_date',
+                    'term_days',
+                    'cl_currencies_id',
+                ]
+            ),
+            $parameters
+        );
+
+        if ( count( $missingRequiredParameters ) !== 0 ) {
+            $missingKeys = implode( ', ', array_keys( $missingRequiredParameters ) );
+
+            throw new \InvalidArgumentException(
+                "Missing required parameter(s): $missingKeys"
+            );
+        }
+
+        $response = $this->client->request(
+            'PATCH',
+            'purchase_invoices/' . $id,
+            [],
+            $parameters
+        );
+
+        return $response;
+    }
+
+    /**
+     * Delete one specific purchase invoice of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/delete-purchase_invoices_one
+     *
+     * @param int $id Purchase invoice identificator.
+     *
+     * @return mixed
+     */
+    public function delete( int $id ): mixed
+    {
+        $response = $this->client->request( 'DELETE', 'purchase_invoices/' . $id );
+
+        return $response;
+    }
+
+    /**
+     * Register one specific purchase invoice of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/patch-purchase_invoices_one_register
+     *
+     * @param int $id Purchase invoice identificator.
+     *
+     * @return mixed
+     */
+    public function register( int $id ): mixed
+    {
+        $response = $this->client->request( 'PATCH', 'purchase_invoices/' . $id . '/register' );
+
+        return $response;
+    }
+
+    /**
+     * Invalidate one specific purchase invoice of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/patch-purchase_invoices_one_invalidate
+     *
+     * @param int $id Purchase invoice identificator.
+     *
+     * @return mixed
+     */
+    public function invalidate( int $id ): mixed
+    {
+        $response = $this->client->request( 'PATCH', 'purchase_invoices/' . $id . '/invalidate' );
+
+        return $response;
+    }
+
+    /**
+     * Retrieve the user-uploaded document related to a purchase invoice.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/get-purchase_invoices_one_document_user
+     *
+     * @param int $id Purchase invoice identificator.
+     *
+     * @return mixed
+     */
+    public function getFile( int $id ): mixed
+    {
+        $response = $this->client->request( 'GET', 'purchase_invoices/' . $id . '/document_user' );
+
+        return $response;
+    }
+
+    /**
+     * Update the user-uploaded document related to a purchase invoice.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/put-purchase_invoices_one_document_user
+     *
+     * @param int $id Purchase invoice identificator.
+     * @param array<string,mixed>|array{
+     *   "name": string,
+     *   "contents": string,
+     * } $parameters Base64-encoded file payload.
+     *
+     * @return mixed
+     */
+    public function updateFile( int $id, array $parameters ): mixed
+    {
+        $missingRequiredParameters = array_diff_key(
+            array_flip(
+                [
+                    'name',
+                    'contents',
+                ]
+            ),
+            $parameters
+        );
+
+        if ( count( $missingRequiredParameters ) !== 0 ) {
+            $missingKeys = implode( ', ', array_keys( $missingRequiredParameters ) );
+
+            throw new \InvalidArgumentException(
+                "Missing required parameter(s): $missingKeys"
+            );
+        }
+
+        $response = $this->client->request(
+            'PUT',
+            'purchase_invoices/' . $id . '/document_user',
+            [],
+            $parameters
+        );
+
+        return $response;
+    }
+
+    /**
+     * Delete the user-uploaded document related to a purchase invoice.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/delete-purchase_invoices_one_document_user
+     *
+     * @param int $id Purchase invoice identificator.
+     *
+     * @return mixed
+     */
+    public function deleteFile( int $id ): mixed
+    {
+        $response = $this->client->request( 'DELETE', 'purchase_invoices/' . $id . '/document_user' );
+
+        return $response;
+    }
+}

--- a/src/API/SalesInvoices.php
+++ b/src/API/SalesInvoices.php
@@ -1,0 +1,423 @@
+<?php
+
+namespace EFinancialsClient\API;
+
+use DateTime;
+
+class SalesInvoices extends AbstractAPI
+{
+    /**
+     * Retrieve the sale invoice list of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/get-sale_invoices
+     *
+     * @param int             $page Page of responses to return.
+     * @param DateTime|string $modifiedSince Return only objects modified since provided timestamp.
+     * @param DateTime|string $startDate Object revenue date on given date or later.
+     * @param DateTime|string $endDate Object revenue date on given date or before.
+     * @param string          $status Object status.
+     * @param string          $paymentStatus Object payment status.
+     * @param int|null        $clientsId Customer identificator.
+     *
+     * @return mixed
+     */
+    public function all(
+        int $page = 1,
+        DateTime|string $modifiedSince = '',
+        DateTime|string $startDate = '',
+        DateTime|string $endDate = '',
+        string $status = '',
+        string $paymentStatus = '',
+        ?int $clientsId = null,
+    ): mixed {
+        $query = [];
+
+        if ( $page !== 1 ) {
+            $query['page'] = $page;
+        }
+
+        if ( $modifiedSince !== '' ) {
+            $query['modified_since'] = ( $modifiedSince instanceof DateTime )
+                ? $modifiedSince->format( \DateTimeInterface::ATOM )
+                : $modifiedSince;
+        }
+
+        if ( $startDate !== '' ) {
+            $query['start_date'] = ( $startDate instanceof DateTime )
+                ? $startDate->format( 'Y-m-d' )
+                : $startDate;
+        }
+
+        if ( $endDate !== '' ) {
+            $query['end_date'] = ( $endDate instanceof DateTime )
+                ? $endDate->format( 'Y-m-d' )
+                : $endDate;
+        }
+
+        if ( $status !== '' ) {
+            $query['status'] = $status;
+        }
+
+        if ( $paymentStatus !== '' ) {
+            $query['payment_status'] = $paymentStatus;
+        }
+
+        if ( $clientsId !== null ) {
+            $query['clients_id'] = $clientsId;
+        }
+
+        $response = $this->client->request( 'GET', 'sale_invoices', $query );
+
+        return $response;
+    }
+
+    /**
+     * Retrieve one specific sale invoice of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/get-sale_invoices_one
+     *
+     * @param int $id Sale invoice identificator.
+     *
+     * @return mixed
+     */
+    public function get( int $id ): mixed
+    {
+        $response = $this->client->request( 'GET', 'sale_invoices/' . $id );
+
+        return $response;
+    }
+
+    /**
+     * Create a new sale invoice of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/post-sale_invoices
+     *
+     * @param array<string,mixed>|array{
+     *   "sale_invoice_type": "INVOICE",
+     *   "cl_templates_id": 1,
+     *   "clients_id": 126,
+     *   "cl_countries_id": "EST",
+     *   "number_suffix": "91",
+     *   "create_date": "2016-02-15",
+     *   "journal_date": "2016-02-15",
+     *   "term_days": 30,
+     *   "cl_currencies_id": "EUR",
+     *   "show_client_balance": false
+     * } $parameters
+     *
+     * @return mixed
+     */
+    public function create( array $parameters = [] ): mixed
+    {
+        $missingRequiredParameters = array_diff_key(
+            array_flip(
+                [
+                    'sale_invoice_type',
+                    'cl_templates_id',
+                    'clients_id',
+                    'cl_countries_id',
+                    'number_suffix',
+                    'create_date',
+                    'journal_date',
+                    'term_days',
+                    'cl_currencies_id',
+                    'show_client_balance',
+                ]
+            ),
+            $parameters
+        );
+
+        if ( count( $missingRequiredParameters ) !== 0 ) {
+            $missingKeys = implode( ', ', array_keys( $missingRequiredParameters ) );
+
+            throw new \InvalidArgumentException(
+                "Missing required parameter(s): $missingKeys"
+            );
+        }
+
+        $response = $this->client->request(
+            'POST',
+            'sale_invoices',
+            [],
+            $parameters
+        );
+
+        return $response;
+    }
+
+    /**
+     * Modify one specific sale invoice of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/patch-sale_invoices_one
+     *
+     * @param int $id Sale invoice identificator.
+     * @param array<string,mixed>|array{
+     *   "sale_invoice_type": "INVOICE",
+     *   "cl_templates_id": 1,
+     *   "clients_id": 126,
+     *   "cl_countries_id": "EST",
+     *   "number_suffix": "91",
+     *   "create_date": "2016-02-15",
+     *   "journal_date": "2016-02-15",
+     *   "term_days": 30,
+     *   "cl_currencies_id": "EUR",
+     *   "show_client_balance": false
+     * } $parameters
+     *
+     * @return mixed
+     */
+    public function update( int $id, array $parameters ): mixed
+    {
+        $missingRequiredParameters = array_diff_key(
+            array_flip(
+                [
+                    'sale_invoice_type',
+                    'cl_templates_id',
+                    'clients_id',
+                    'cl_countries_id',
+                    'number_suffix',
+                    'create_date',
+                    'journal_date',
+                    'term_days',
+                    'cl_currencies_id',
+                    'show_client_balance',
+                ]
+            ),
+            $parameters
+        );
+
+        if ( count( $missingRequiredParameters ) !== 0 ) {
+            $missingKeys = implode( ', ', array_keys( $missingRequiredParameters ) );
+
+            throw new \InvalidArgumentException(
+                "Missing required parameter(s): $missingKeys"
+            );
+        }
+
+        $response = $this->client->request(
+            'PATCH',
+            'sale_invoices/' . $id,
+            [],
+            $parameters
+        );
+
+        return $response;
+    }
+
+    /**
+     * Delete one specific sale invoice of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/delete-sale_invoices_one
+     *
+     * @param int $id Sale invoice identificator.
+     *
+     * @return mixed
+     */
+    public function delete( int $id ): mixed
+    {
+        $response = $this->client->request( 'DELETE', 'sale_invoices/' . $id );
+
+        return $response;
+    }
+
+    /**
+     * Register one specific sale invoice of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/patch-sale_invoices_one_register
+     *
+     * @param int $id Sale invoice identificator.
+     *
+     * @return mixed
+     */
+    public function register( int $id ): mixed
+    {
+        $response = $this->client->request( 'PATCH', 'sale_invoices/' . $id . '/register' );
+
+        return $response;
+    }
+
+    /**
+     * Invalidate one specific sale invoice of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/patch-sale_invoices_one_invalidate
+     *
+     * @param int $id Sale invoice identificator.
+     *
+     * @return mixed
+     */
+    public function invalidate( int $id ): mixed
+    {
+        $response = $this->client->request( 'PATCH', 'sale_invoices/' . $id . '/invalidate' );
+
+        return $response;
+    }
+
+    /**
+     * Retrieve the system-generated XML e-invoice related to a sale invoice.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/get-sale_invoices_one_xml
+     *
+     * @param int $id Sale invoice identificator.
+     *
+     * @return mixed
+     */
+    public function getXml( int $id ): mixed
+    {
+        $response = $this->client->request( 'GET', 'sale_invoices/' . $id . '/xml' );
+
+        return $response;
+    }
+
+    /**
+     * Retrieve the system-generated PDF related to a sale invoice.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/get-sale_invoices_one_document_system
+     *
+     * @param int $id Sale invoice identificator.
+     *
+     * @return mixed
+     */
+    public function getSystemPdf( int $id ): mixed
+    {
+        $response = $this->client->request( 'GET', 'sale_invoices/' . $id . '/pdf_system' );
+
+        return $response;
+    }
+
+    /**
+     * Retrieve the user-uploaded document related to a sale invoice.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/get-sale_invoices_one_document_user
+     *
+     * @param int $id Sale invoice identificator.
+     *
+     * @return mixed
+     */
+    public function getFile( int $id ): mixed
+    {
+        $response = $this->client->request( 'GET', 'sale_invoices/' . $id . '/document_user' );
+
+        return $response;
+    }
+
+    /**
+     * Update the user-uploaded document related to a sale invoice.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/put-sale_invoices_one_document_user
+     *
+     * @param int $id Sale invoice identificator.
+     * @param array<string,mixed>|array{
+     *   "name": string,
+     *   "contents": string,
+     * } $parameters Base64-encoded file payload.
+     *
+     * @return mixed
+     */
+    public function updateFile( int $id, array $parameters ): mixed
+    {
+        $missingRequiredParameters = array_diff_key(
+            array_flip(
+                [
+                    'name',
+                    'contents',
+                ]
+            ),
+            $parameters
+        );
+
+        if ( count( $missingRequiredParameters ) !== 0 ) {
+            $missingKeys = implode( ', ', array_keys( $missingRequiredParameters ) );
+
+            throw new \InvalidArgumentException(
+                "Missing required parameter(s): $missingKeys"
+            );
+        }
+
+        $response = $this->client->request(
+            'PUT',
+            'sale_invoices/' . $id . '/document_user',
+            [],
+            $parameters
+        );
+
+        return $response;
+    }
+
+    /**
+     * Delete the user-uploaded document related to a sale invoice.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/delete-sale_invoices_one_document_user
+     *
+     * @param int $id Sale invoice identificator.
+     *
+     * @return mixed
+     */
+    public function deleteFile( int $id ): mixed
+    {
+        $response = $this->client->request( 'DELETE', 'sale_invoices/' . $id . '/document_user' );
+
+        return $response;
+    }
+
+    /**
+     * Retrieve delivery options for one specific sale invoice.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/get-sale_invoices_one_delivery_opts
+     *
+     * @param int $id Sale invoice identificator.
+     *
+     * @return mixed
+     */
+    public function getDeliveryOptions( int $id ): mixed
+    {
+        $response = $this->client->request( 'GET', 'sale_invoices/' . $id . '/delivery_options' );
+
+        return $response;
+    }
+
+    /**
+     * Send one specific sale invoice to the customer.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/patch-sale_invoices_one_deliver
+     *
+     * @param int $id Sale invoice identificator.
+     * @param array<string,mixed>|array{
+     *   "send_einvoice": bool,
+     *   "send_email": bool,
+     *   "email_addresses": string,
+     *   "email_subject": string,
+     *   "email_body": string,
+     * } $parameters
+     *
+     * @return mixed
+     */
+    public function deliver( int $id, array $parameters ): mixed
+    {
+        $missingRequiredParameters = array_diff_key(
+            array_flip(
+                [
+                    'send_einvoice',
+                    'send_email',
+                ]
+            ),
+            $parameters
+        );
+
+        if ( count( $missingRequiredParameters ) !== 0 ) {
+            $missingKeys = implode( ', ', array_keys( $missingRequiredParameters ) );
+
+            throw new \InvalidArgumentException(
+                "Missing required parameter(s): $missingKeys"
+            );
+        }
+
+        $response = $this->client->request(
+            'PATCH',
+            'sale_invoices/' . $id . '/deliver',
+            [],
+            $parameters
+        );
+
+        return $response;
+    }
+}

--- a/src/API/Templates.php
+++ b/src/API/Templates.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace EFinancialsClient\API;
+
+class Templates extends AbstractAPI
+{
+    /**
+     * Retrieve the sale invoice templates of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/get-templates
+     *
+     * @return mixed
+     */
+    public function all(): mixed
+    {
+        $response = $this->client->request( 'GET', 'templates' );
+
+        return $response;
+    }
+}

--- a/src/API/Transactions.php
+++ b/src/API/Transactions.php
@@ -1,0 +1,319 @@
+<?php
+
+namespace EFinancialsClient\API;
+
+use DateTime;
+
+class Transactions extends AbstractAPI
+{
+    /**
+     * Retrieve the transaction list of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/get-transactions
+     *
+     * @param int             $page Page of responses to return.
+     * @param DateTime|string $modifiedSince Return only objects modified since provided timestamp.
+     * @param DateTime|string $startDate Date on given date or later.
+     * @param DateTime|string $endDate Date on given date or before.
+     * @param string          $status Object status.
+     * @param string          $type Object type.
+     * @param int|null        $clientsId Customer identificator.
+     *
+     * @return mixed
+     */
+    public function all(
+        int $page = 1,
+        DateTime|string $modifiedSince = '',
+        DateTime|string $startDate = '',
+        DateTime|string $endDate = '',
+        string $status = '',
+        string $type = '',
+        ?int $clientsId = null,
+    ): mixed {
+        $query = [];
+
+        if ( $page !== 1 ) {
+            $query['page'] = $page;
+        }
+
+        if ( $modifiedSince !== '' ) {
+            $query['modified_since'] = ( $modifiedSince instanceof DateTime )
+                ? $modifiedSince->format( \DateTimeInterface::ATOM )
+                : $modifiedSince;
+        }
+
+        if ( $startDate !== '' ) {
+            $query['start_date'] = ( $startDate instanceof DateTime )
+                ? $startDate->format( 'Y-m-d' )
+                : $startDate;
+        }
+
+        if ( $endDate !== '' ) {
+            $query['end_date'] = ( $endDate instanceof DateTime )
+                ? $endDate->format( 'Y-m-d' )
+                : $endDate;
+        }
+
+        if ( $status !== '' ) {
+            $query['status'] = $status;
+        }
+
+        if ( $type !== '' ) {
+            $query['type'] = $type;
+        }
+
+        if ( $clientsId !== null ) {
+            $query['clients_id'] = $clientsId;
+        }
+
+        $response = $this->client->request( 'GET', 'transactions', $query );
+
+        return $response;
+    }
+
+    /**
+     * Retrieve one specific transaction of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/get-transactions_one
+     *
+     * @param int $id Transaction identificator.
+     *
+     * @return mixed
+     */
+    public function get( int $id ): mixed
+    {
+        $response = $this->client->request( 'GET', 'transactions/' . $id );
+
+        return $response;
+    }
+
+    /**
+     * Create a new transaction of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/post-transactions
+     *
+     * @param array<string,mixed>|array{
+     *   "accounts_dimensions_id": int,
+     *   "type": "D"|"C",
+     *   "amount": float,
+     *   "cl_currencies_id": "EUR",
+     *   "date": "2015-01-31",
+     *   "description": string,
+     *   "clients_id": int,
+     * } $parameters
+     *
+     * @return mixed
+     */
+    public function create( array $parameters = [] ): mixed
+    {
+        $missingRequiredParameters = array_diff_key(
+            array_flip(
+                [
+                    'accounts_dimensions_id',
+                    'type',
+                    'amount',
+                    'cl_currencies_id',
+                    'date',
+                ]
+            ),
+            $parameters
+        );
+
+        if ( count( $missingRequiredParameters ) !== 0 ) {
+            $missingKeys = implode( ', ', array_keys( $missingRequiredParameters ) );
+
+            throw new \InvalidArgumentException(
+                "Missing required parameter(s): $missingKeys"
+            );
+        }
+
+        $response = $this->client->request(
+            'POST',
+            'transactions',
+            [],
+            $parameters
+        );
+
+        return $response;
+    }
+
+    /**
+     * Modify one specific transaction of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/patch-transactions_one
+     *
+     * @param int $id Transaction identificator.
+     * @param array<string,mixed>|array{
+     *   "accounts_dimensions_id": int,
+     *   "type": "D"|"C",
+     *   "amount": float,
+     *   "cl_currencies_id": "EUR",
+     *   "date": "2015-01-31",
+     *   "description": string,
+     *   "clients_id": int,
+     * } $parameters
+     *
+     * @return mixed
+     */
+    public function update( int $id, array $parameters ): mixed
+    {
+        $missingRequiredParameters = array_diff_key(
+            array_flip(
+                [
+                    'accounts_dimensions_id',
+                    'type',
+                    'amount',
+                    'cl_currencies_id',
+                    'date',
+                ]
+            ),
+            $parameters
+        );
+
+        if ( count( $missingRequiredParameters ) !== 0 ) {
+            $missingKeys = implode( ', ', array_keys( $missingRequiredParameters ) );
+
+            throw new \InvalidArgumentException(
+                "Missing required parameter(s): $missingKeys"
+            );
+        }
+
+        $response = $this->client->request(
+            'PATCH',
+            'transactions/' . $id,
+            [],
+            $parameters
+        );
+
+        return $response;
+    }
+
+    /**
+     * Delete one specific transaction of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/delete-transactions_one
+     *
+     * @param int $id Transaction identificator.
+     *
+     * @return mixed
+     */
+    public function delete( int $id ): mixed
+    {
+        $response = $this->client->request( 'DELETE', 'transactions/' . $id );
+
+        return $response;
+    }
+
+    /**
+     * Register one specific transaction of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/patch-transactions_one_register
+     *
+     * @param int                  $id Transaction identificator.
+     * @param array<int, mixed>    $distributions Optional transaction distribution rows.
+     *
+     * @return mixed
+     */
+    public function register( int $id, array $distributions = [] ): mixed
+    {
+        $response = $this->client->request(
+            'PATCH',
+            'transactions/' . $id . '/register',
+            [],
+            $distributions
+        );
+
+        return $response;
+    }
+
+    /**
+     * Invalidate one specific transaction of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/patch-transactions_one_invalidate
+     *
+     * @param int $id Transaction identificator.
+     *
+     * @return mixed
+     */
+    public function invalidate( int $id ): mixed
+    {
+        $response = $this->client->request( 'PATCH', 'transactions/' . $id . '/invalidate' );
+
+        return $response;
+    }
+
+    /**
+     * Retrieve the document related to a transaction of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/get-transactions_one_document_user
+     *
+     * @param int $id Transaction identificator.
+     *
+     * @return mixed
+     */
+    public function getFile( int $id ): mixed
+    {
+        $response = $this->client->request( 'GET', 'transactions/' . $id . '/document_user' );
+
+        return $response;
+    }
+
+    /**
+     * Update the document related to a transaction of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/put-transactions_one_document_user
+     *
+     * @param int $id Transaction identificator.
+     * @param array<string,mixed>|array{
+     *   "name": string,
+     *   "contents": string,
+     * } $parameters Base64-encoded file payload.
+     *
+     * @return mixed
+     */
+    public function updateFile( int $id, array $parameters ): mixed
+    {
+        $missingRequiredParameters = array_diff_key(
+            array_flip(
+                [
+                    'name',
+                    'contents',
+                ]
+            ),
+            $parameters
+        );
+
+        if ( count( $missingRequiredParameters ) !== 0 ) {
+            $missingKeys = implode( ', ', array_keys( $missingRequiredParameters ) );
+
+            throw new \InvalidArgumentException(
+                "Missing required parameter(s): $missingKeys"
+            );
+        }
+
+        $response = $this->client->request(
+            'PUT',
+            'transactions/' . $id . '/document_user',
+            [],
+            $parameters
+        );
+
+        return $response;
+    }
+
+    /**
+     * Delete the document related to a transaction of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/delete-transactions_one_document_user
+     *
+     * @param int $id Transaction identificator.
+     *
+     * @return mixed
+     */
+    public function deleteFile( int $id ): mixed
+    {
+        $response = $this->client->request( 'DELETE', 'transactions/' . $id . '/document_user' );
+
+        return $response;
+    }
+}

--- a/src/Client.php
+++ b/src/Client.php
@@ -9,16 +9,17 @@ use Psr\Http\Message\ResponseInterface;
 
 class Client
 {
+    private GuzzleClient $httpClient;
+
     public function __construct(
-        private ?GuzzleClient $httpClient = null,
+        ?GuzzleClient $httpClient = null,
         private string $apiKeyId = '',
         private string $apiKeyPublic = '',
         private string $apiKeyPassword = '',
         private string $apiUrl = "https://demo-rmp-api.rik.ee",
         private string $apiVersion = "v1"
     ) {
-
-        $this->httpClient = new GuzzleClient(
+        $this->httpClient = $httpClient ?? new GuzzleClient(
             [
                 'base_uri' => $this->apiUrl,
                 'headers'  => [
@@ -32,11 +33,13 @@ class Client
      * Creates authorization key for HTTP header.
      * For more detailed description check e-Financials API doc.
      *
-     * @param string $path Relative path of url request.
+     * @param string      $path Relative path of url request.
+     * @param string|null $queryTime UTC timestamp used in X-AUTH-QUERYTIME.
      */
-    public function createAuthKey( string $path ): string
+    public function createAuthKey( string $path, ?string $queryTime = null ): string
     {
-        $data = $this->apiKeyId . ':' . $this->createAuthQuerytime() . ':' . $path;
+        $queryTime ??= $this->createAuthQuerytime();
+        $data = $this->apiKeyId . ':' . $queryTime . ':' . $path;
         $key = $this->apiKeyPassword;
 
         $requestSignature = base64_encode( hash_hmac( 'sha384', $data, $key, true ) );
@@ -65,14 +68,10 @@ class Client
      */
     public function request( string $method, string $endpoint, array $query = [], array $body = [] ): mixed
     {
-        if ( is_null( $this->httpClient ) ) {
-            return null;
-        }
-
         $endpoint = '/' . $this->apiVersion . '/' . $endpoint;
 
         $queryTime = $this->createAuthQuerytime();
-        $authKey   = $this->createAuthKey( $endpoint );
+        $authKey   = $this->createAuthKey( $endpoint, $queryTime );
         $headers   = [
             'X-AUTH-QUERYTIME' => $queryTime,
             'X-AUTH-KEY'       => $authKey,
@@ -165,5 +164,30 @@ class Client
     public function bank(): API\Bank
     {
         return new API\Bank( $this );
+    }
+
+    public function journals(): API\Journals
+    {
+        return new API\Journals( $this );
+    }
+
+    public function transactions(): API\Transactions
+    {
+        return new API\Transactions( $this );
+    }
+
+    public function salesInvoices(): API\SalesInvoices
+    {
+        return new API\SalesInvoices( $this );
+    }
+
+    public function purchaseInvoices(): API\PurchaseInvoices
+    {
+        return new API\PurchaseInvoices( $this );
+    }
+
+    public function templates(): API\Templates
+    {
+        return new API\Templates( $this );
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements the remaining e-Financials / e-Arveldaja OpenAPI endpoints so the PHP client covers all 78 documented operations (#24).

## Changes
- **Journals** — list/get/create/update/delete, register/invalidate, document get/update/delete
- **Transactions** — list/get/create/update/delete, register/invalidate, document get/update/delete
- **Sales invoices** — full CRUD, register/invalidate, XML/PDF/user files, delivery options + deliver
- **Purchase invoices** — full CRUD, register/invalidate, user file get/update/delete
- **Templates** — list sale invoice templates
- **Invoice series** — add missing `delete()`
- **Client** — use the same `X-AUTH-QUERYTIME` value when signing; respect an injected Guzzle client; expose new resource accessors
- **README** — usage and resource map

Auth signing follows [RIK Abiinfo #304](https://abiinfo.rik.ee/node/304/): `BASE64(HMAC-SHA-384("{apiKeyId}:{queryTime}:{path}", password))`.

## Verification
- Endpoint coverage checked against `https://demo-rmp-api.rik.ee/openapi.yaml` (78/78)
- PHPStan and Psalm pass locally on the new/changed code

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc257-d455-7e35-8918-856ab318b3a5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc257-d455-7e35-8918-856ab318b3a5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

