### PR TITLE
chore(deps): Pest 5 tooling upgrade and dependency refresh

### DIFF
--- a/.github/workflows/formats.yml
+++ b/.github/workflows/formats.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.2]
+        php: [8.4]
         dependency-version: [prefer-lowest, prefer-stable]
 
     name: Formats P${{ matrix.php }} - ${{ matrix.os }} - ${{ matrix.dependency-version }}
@@ -20,16 +20,16 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Cache dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ~/.composer/cache/files
         key: dependencies-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
 
     - name: Setup PHP
-      uses: shivammathur/setup-php@v2
+      uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
       with:
         php-version: ${{ matrix.php }}
         extensions: dom, mbstring, zip

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,13 +12,17 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.2, 8.3, 8.4, 8.5]
-        pest: [3, 4]
+        pest: [3, 4, 5]
         dependency-version: [prefer-lowest, prefer-stable]
         exclude:
           - php: 8.5
             pest: 3
           - php: 8.2
             pest: 4
+          - php: 8.2
+            pest: 5
+          - php: 8.3
+            pest: 5
 
     name: Tests P${{ matrix.php }} - Pest ${{ matrix.pest }} - ${{ matrix.os }} - ${{ matrix.dependency-version }}
 
@@ -34,7 +38,7 @@ jobs:
         key: dependencies-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
 
     - name: Setup PHP
-      uses: shivammathur/setup-php@v2
+      uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
       with:
         php-version: ${{ matrix.php }}
         extensions: dom, mbstring, zip

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,20 +11,10 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.2, 8.3, 8.4, 8.5]
-        pest: [3, 4, 5]
+        php: [8.4, 8.5]
         dependency-version: [prefer-lowest, prefer-stable]
-        exclude:
-          - php: 8.5
-            pest: 3
-          - php: 8.2
-            pest: 4
-          - php: 8.2
-            pest: 5
-          - php: 8.3
-            pest: 5
 
-    name: Tests P${{ matrix.php }} - Pest ${{ matrix.pest }} - ${{ matrix.os }} - ${{ matrix.dependency-version }}
+    name: Tests P${{ matrix.php }} - ${{ matrix.os }} - ${{ matrix.dependency-version }}
 
     steps:
 
@@ -44,11 +34,36 @@ jobs:
         extensions: dom, mbstring, zip
         coverage: none
 
-    - name: Install Pest
-      run: composer require pestphp/pest:^${{ matrix.pest }} --dev --no-update --with-all-dependencies
-
     - name: Install Composer dependencies
       run: composer update --${{ matrix.dependency-version }} --no-interaction --prefer-dist
 
     - name: Unit Tests
       run: composer test:unit
+
+  mutate:
+    runs-on: ubuntu-latest
+    name: Mutation Tests
+
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+    - name: Cache dependencies
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/.composer/cache/files
+        key: dependencies-php-8.4-composer-${{ hashFiles('composer.json') }}-mutate
+
+    - name: Setup PHP
+      uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+      with:
+        php-version: '8.4'
+        extensions: dom, mbstring, zip
+        coverage: pcov
+
+    - name: Install Composer dependencies
+      run: composer update --prefer-stable --no-interaction --prefer-dist
+
+    - name: Mutation Tests
+      run: composer test:mutate

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /.phpunit.cache
 /.php-cs-fixer.cache
 /.php-cs-fixer.php
+/.pest
 /composer.lock
 /phpunit.xml
 /vendor/

--- a/README.md
+++ b/README.md
@@ -68,11 +68,16 @@ Requires PHP 8.2+.
 
 ```bash
 composer install
-composer test        # lint + types + type-coverage + unit
-composer lint        # Laravel Pint
-composer test:types  # PHPStan
-composer test:unit   # Pest
+composer test         # lint + types + type-coverage + unit
+composer lint         # Laravel Pint
+composer test:types   # PHPStan
+composer test:unit    # Pest 5
+composer test:mutate  # Pest mutation testing (requires PCOV/Xdebug)
 ```
+
+Dev tooling targets PHP 8.4+ (Pest 5). The library runtime still supports PHP 8.2+.
+
+Mutation testing currently applies a local Composer patch for [pestphp/pest#1790](https://github.com/pestphp/pest/issues/1790) (`php-code-coverage` 14 `--coverage-php` format); remove `patches/` once upstream ships the fix.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 

--- a/composer.json
+++ b/composer.json
@@ -10,18 +10,23 @@
         "psr/http-client": "^1.0.3",
         "psr/http-client-implementation": "^1.0.1",
         "psr/http-factory-implementation": "*",
-        "psr/http-message": "^1.1.0|^2.0.0"
+        "psr/http-message": "^2.0.0"
     },
     "require-dev": {
-        "guzzlehttp/guzzle": "^7.5|^8.0.1",
+        "cweagans/composer-patches": "^1.7.3",
+        "guzzlehttp/guzzle": "^8.0.1",
+        "guzzlehttp/psr7": "^3.0.0",
         "laravel/pint": "^1.30.3",
         "mockery/mockery": "^1.6.12",
         "nunomaduro/collision": "^8.9.5",
-        "pestphp/pest": "^3.8.2|^4.1.4|^5.0.2",
-        "pestphp/pest-plugin-arch": "^3.1.1|^4.0.0|^5.0.0",
-        "pestphp/pest-plugin-type-coverage": "^3.5.1|^4.0.0|^5.0.0",
+        "pestphp/pest": "^5.0.2",
+        "pestphp/pest-plugin-arch": "^5.0.0",
+        "pestphp/pest-plugin-mutate": "^5.0.0",
+        "pestphp/pest-plugin-type-coverage": "^5.0.0",
         "phpstan/phpstan": "^2.2.7",
-        "symfony/var-dumper": "^7.3.5|^8.1.2"
+        "phpstan/phpstan-deprecation-rules": "^2.0.5",
+        "phpstan/phpstan-strict-rules": "^2.0.12",
+        "symfony/var-dumper": "^8.1.2"
     },
     "autoload": {
         "psr-4": {
@@ -42,8 +47,16 @@
         "sort-packages": true,
         "preferred-install": "dist",
         "allow-plugins": {
+            "cweagans/composer-patches": true,
             "pestphp/pest-plugin": true,
             "php-http/discovery": false
+        }
+    },
+    "extra": {
+        "patches": {
+            "pestphp/pest-plugin-mutate": {
+                "Fix php-code-coverage 14 coverage-php array format (pestphp/pest#1790)": "patches/pest-plugin-mutate-coverage-php-14.patch"
+            }
         }
     },
     "scripts": {
@@ -52,6 +65,7 @@
         "test:types": "phpstan analyse --ansi",
         "test:type-coverage": "phpstan analyse -c phpstan-type-coverage.neon.dist --ansi",
         "test:unit": "pest --colors=always",
+        "test:mutate": "pest --mutate --parallel --everything --covered-only --min=20 --colors=always",
         "test": [
             "@test:lint",
             "@test:types",

--- a/composer.json
+++ b/composer.json
@@ -13,15 +13,15 @@
         "psr/http-message": "^1.1.0|^2.0.0"
     },
     "require-dev": {
-        "guzzlehttp/guzzle": "^7.5",
-        "laravel/pint": "^1.25.1",
+        "guzzlehttp/guzzle": "^7.5|^8.0.1",
+        "laravel/pint": "^1.30.3",
         "mockery/mockery": "^1.6.12",
-        "nunomaduro/collision": "^8.8.3",
-        "pestphp/pest": "^3.8.2|^4.1.4",
-        "pestphp/pest-plugin-arch": "^3.1.1|^4.0.0",
-        "pestphp/pest-plugin-type-coverage": "^3.5.1|^4.0.0",
-        "phpstan/phpstan": "^1.12.32",
-        "symfony/var-dumper": "^7.3.5"
+        "nunomaduro/collision": "^8.9.5",
+        "pestphp/pest": "^3.8.2|^4.1.4|^5.0.2",
+        "pestphp/pest-plugin-arch": "^3.1.1|^4.0.0|^5.0.0",
+        "pestphp/pest-plugin-type-coverage": "^3.5.1|^4.0.0|^5.0.0",
+        "phpstan/phpstan": "^2.2.7",
+        "symfony/var-dumper": "^7.3.5|^8.1.2"
     },
     "autoload": {
         "psr-4": {

--- a/patches/pest-plugin-mutate-coverage-php-14.patch
+++ b/patches/pest-plugin-mutate-coverage-php-14.patch
@@ -1,0 +1,43 @@
+diff --git a/src/Tester/MutationTestRunner.php b/src/Tester/MutationTestRunner.php
+index e2d1aea..01898b7 100644
+--- a/src/Tester/MutationTestRunner.php
++++ b/src/Tester/MutationTestRunner.php
+@@ -20,6 +20,7 @@
+ use Pest\Support\Coverage;
+ use Psr\SimpleCache\CacheInterface;
+ use SebastianBergmann\CodeCoverage\CodeCoverage;
++use SebastianBergmann\CodeCoverage\Data\ProcessedCodeCoverageData;
+ 
+ class MutationTestRunner implements MutationTestRunnerContract
+ {
+@@ -109,11 +110,27 @@ public function run(): int
+ 
+         Facade::instance()->emitter()->startMutationGeneration($mutationSuite);
+ 
+-        /** @var CodeCoverage $codeCoverage */
+-        $codeCoverage = require $reportPath;
++        /** @var CodeCoverage|array{basePath: string, codeCoverage: ProcessedCodeCoverageData} $loadedCoverage */
++        $loadedCoverage = require $reportPath;
+ 
+         unlink($reportPath);
+-        $coveredLines = array_map(fn (array $lines): array => array_filter($lines, fn (?array $tests): bool => $tests !== [] && $tests !== null), $codeCoverage->getData()->lineCoverage());
++
++        if ($loadedCoverage instanceof CodeCoverage) {
++            $coverageData = $loadedCoverage->getData();
++        } else {
++            // since phpunit/php-code-coverage 14, `--coverage-php` writes an array instead of a
++            // serialized CodeCoverage, and its file keys are relative to `basePath`
++            $coverageData = $loadedCoverage['codeCoverage'];
++            $basePath = $loadedCoverage['basePath'];
++
++            if ($basePath !== '') {
++                foreach ($coverageData->coveredFiles() as $relativePath) {
++                    $coverageData->renameFile($relativePath, $basePath.DIRECTORY_SEPARATOR.$relativePath);
++                }
++            }
++        }
++
++        $coveredLines = array_map(fn (array $lines): array => array_filter($lines, fn (?array $tests): bool => $tests !== [] && $tests !== null), $coverageData->lineCoverage());
+         $coveredLines = array_filter($coveredLines, fn (array $lines): bool => $lines !== []);
+ 
+         $files = FileFinder::files($this->getConfiguration()->paths, $this->getConfiguration()->pathsToIgnore);

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,4 +1,10 @@
+includes:
+    - phar://phpstan.phar/conf/bleedingEdge.neon
+    - vendor/phpstan/phpstan-strict-rules/rules.neon
+    - vendor/phpstan/phpstan-deprecation-rules/rules.neon
+
 parameters:
+    phpVersion: 80200
     level: max
     paths:
         - src

--- a/src/Contracts/ResponseContract.php
+++ b/src/Contracts/ResponseContract.php
@@ -34,7 +34,7 @@ interface ResponseContract extends ArrayAccess
     /**
      * @template TOffsetKey of key-of<TArray>
      *
-     * @param  TOffsetKey  $offset
+     * @param  TOffsetKey|null  $offset
      * @param  TArray[TOffsetKey]  $value
      */
     public function offsetSet(mixed $offset, mixed $value): never;

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -118,7 +118,10 @@ final class Factory
             $headers = $headers->withCustomHeader($name, $value);
         }
 
-        $baseUri = BaseUri::from($this->baseUri ?: 'https://demo-rmp-api.rik.ee', $this->apiVersion);
+        $baseUri = BaseUri::from(
+            ($this->baseUri !== null && $this->baseUri !== '') ? $this->baseUri : 'https://demo-rmp-api.rik.ee',
+            $this->apiVersion,
+        );
 
         $client = $this->httpClient ??= Psr18ClientDiscovery::find();
 

--- a/src/Responses/Clients/ClientResponse.php
+++ b/src/Responses/Clients/ClientResponse.php
@@ -6,6 +6,7 @@ namespace EFinancialsClient\Responses\Clients;
 
 use EFinancialsClient\Contracts\ResponseContract;
 use EFinancialsClient\Responses\Concerns\ArrayAccessible;
+use EFinancialsClient\Responses\Concerns\NormalizesAttributes;
 use EFinancialsClient\Testing\Responses\Concerns\Fakeable;
 
 /**
@@ -66,6 +67,7 @@ final class ClientResponse implements ResponseContract
     use ArrayAccessible;
 
     use Fakeable;
+    use NormalizesAttributes;
 
     /**
      * @param  array<string, string>  $invoiceElectronicOpts
@@ -218,73 +220,5 @@ final class ClientResponse implements ResponseContract
             'is_parent_company_group' => $this->isParentCompanyGroup,
             'is_related_party' => $this->isRelatedParty,
         ];
-    }
-
-    private static function stringOrNull(mixed $value): ?string
-    {
-        if ($value === null || $value === '') {
-            return null;
-        }
-
-        if (is_string($value)) {
-            return $value;
-        }
-
-        if (is_int($value) || is_float($value)) {
-            return (string) $value;
-        }
-
-        return null;
-    }
-
-    private static function intOrNull(mixed $value): ?int
-    {
-        if ($value === null || $value === '') {
-            return null;
-        }
-
-        if (is_int($value)) {
-            return $value;
-        }
-
-        if (is_numeric($value)) {
-            return (int) $value;
-        }
-
-        return null;
-    }
-
-    private static function floatOrNull(mixed $value): ?float
-    {
-        if ($value === null || $value === '') {
-            return null;
-        }
-
-        if (is_float($value)) {
-            return $value;
-        }
-
-        if (is_int($value) || (is_string($value) && is_numeric($value))) {
-            return (float) $value;
-        }
-
-        return null;
-    }
-
-    private static function boolOrNull(mixed $value): ?bool
-    {
-        if ($value === null || $value === '') {
-            return null;
-        }
-
-        if (is_bool($value)) {
-            return $value;
-        }
-
-        if (is_int($value) || is_float($value) || is_string($value)) {
-            return (bool) $value;
-        }
-
-        return null;
     }
 }

--- a/src/Responses/Clients/ListResponse.php
+++ b/src/Responses/Clients/ListResponse.php
@@ -6,6 +6,7 @@ namespace EFinancialsClient\Responses\Clients;
 
 use EFinancialsClient\Contracts\ResponseContract;
 use EFinancialsClient\Responses\Concerns\ArrayAccessible;
+use EFinancialsClient\Responses\Concerns\NormalizesAttributes;
 use EFinancialsClient\Testing\Responses\Concerns\Fakeable;
 
 /**
@@ -21,6 +22,7 @@ final class ListResponse implements ResponseContract
     use ArrayAccessible;
 
     use Fakeable;
+    use NormalizesAttributes;
 
     /**
      * @param  array<int, ClientResponse>  $items
@@ -32,18 +34,21 @@ final class ListResponse implements ResponseContract
     ) {}
 
     /**
-     * @param  array{current_page: int, total_pages: int, items: array<int, array<string, mixed>>}  $attributes
+     * @param  array<array-key, mixed>  $attributes
      */
     public static function from(array $attributes): self
     {
+        /** @var array<int, array<string, mixed>> $rawItems */
+        $rawItems = is_array($attributes['items'] ?? null) ? $attributes['items'] : [];
+
         $items = array_map(
             static fn (array $item): ClientResponse => ClientResponse::from($item),
-            $attributes['items'],
+            $rawItems,
         );
 
         return new self(
-            (int) $attributes['current_page'],
-            (int) $attributes['total_pages'],
+            self::intValue($attributes['current_page'] ?? 0),
+            self::intValue($attributes['total_pages'] ?? 0),
             $items,
         );
     }

--- a/src/Responses/Concerns/ArrayAccessible.php
+++ b/src/Responses/Concerns/ArrayAccessible.php
@@ -21,6 +21,10 @@ trait ArrayAccessible
         return $this->toArray()[$offset]; // @phpstan-ignore-line
     }
 
+    /**
+     * @param  key-of<TArray>|null  $offset
+     * @param  value-of<TArray>  $value
+     */
     public function offsetSet(mixed $offset, mixed $value): never
     {
         throw new BadMethodCallException('Cannot set response attributes.');

--- a/src/Responses/Concerns/NormalizesAttributes.php
+++ b/src/Responses/Concerns/NormalizesAttributes.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Responses\Concerns;
+
+/**
+ * @internal
+ */
+trait NormalizesAttributes
+{
+    private static function stringOrNull(mixed $value): ?string
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if (is_string($value)) {
+            return $value;
+        }
+
+        if (is_int($value) || is_float($value)) {
+            return (string) $value;
+        }
+
+        return null;
+    }
+
+    private static function stringValue(mixed $value, string $default = ''): string
+    {
+        return self::stringOrNull($value) ?? $default;
+    }
+
+    private static function intOrNull(mixed $value): ?int
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if (is_int($value)) {
+            return $value;
+        }
+
+        if (is_numeric($value)) {
+            return (int) $value;
+        }
+
+        return null;
+    }
+
+    private static function intValue(mixed $value, int $default = 0): int
+    {
+        return self::intOrNull($value) ?? $default;
+    }
+
+    private static function floatOrNull(mixed $value): ?float
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if (is_float($value)) {
+            return $value;
+        }
+
+        if (is_int($value) || (is_string($value) && is_numeric($value))) {
+            return (float) $value;
+        }
+
+        return null;
+    }
+
+    private static function boolOrNull(mixed $value): ?bool
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        if (is_int($value) || is_float($value) || is_string($value)) {
+            return (bool) $value;
+        }
+
+        return null;
+    }
+
+    private static function boolValue(mixed $value, bool $default = false): bool
+    {
+        return self::boolOrNull($value) ?? $default;
+    }
+}

--- a/src/Responses/Templates/TemplateResponse.php
+++ b/src/Responses/Templates/TemplateResponse.php
@@ -6,6 +6,7 @@ namespace EFinancialsClient\Responses\Templates;
 
 use EFinancialsClient\Contracts\ResponseContract;
 use EFinancialsClient\Responses\Concerns\ArrayAccessible;
+use EFinancialsClient\Responses\Concerns\NormalizesAttributes;
 use EFinancialsClient\Testing\Responses\Concerns\Fakeable;
 
 /**
@@ -19,6 +20,7 @@ final class TemplateResponse implements ResponseContract
     use ArrayAccessible;
 
     use Fakeable;
+    use NormalizesAttributes;
 
     private function __construct(
         public readonly int $id,
@@ -28,15 +30,15 @@ final class TemplateResponse implements ResponseContract
     ) {}
 
     /**
-     * @param  array{id: int, name: string, is_default?: bool, cl_languages_id?: string|null}  $attributes
+     * @param  array<array-key, mixed>  $attributes
      */
     public static function from(array $attributes): self
     {
         return new self(
-            (int) $attributes['id'],
-            (string) $attributes['name'],
-            (bool) ($attributes['is_default'] ?? false),
-            isset($attributes['cl_languages_id']) ? (string) $attributes['cl_languages_id'] : null,
+            self::intValue($attributes['id'] ?? 0),
+            self::stringValue($attributes['name'] ?? ''),
+            self::boolValue($attributes['is_default'] ?? false),
+            self::stringOrNull($attributes['cl_languages_id'] ?? null),
         );
     }
 

--- a/src/Responses/VatInfo/VatInfoResponse.php
+++ b/src/Responses/VatInfo/VatInfoResponse.php
@@ -6,6 +6,7 @@ namespace EFinancialsClient\Responses\VatInfo;
 
 use EFinancialsClient\Contracts\ResponseContract;
 use EFinancialsClient\Responses\Concerns\ArrayAccessible;
+use EFinancialsClient\Responses\Concerns\NormalizesAttributes;
 use EFinancialsClient\Testing\Responses\Concerns\Fakeable;
 
 /**
@@ -19,6 +20,7 @@ final class VatInfoResponse implements ResponseContract
     use ArrayAccessible;
 
     use Fakeable;
+    use NormalizesAttributes;
 
     private function __construct(
         public readonly ?string $vatNumber,
@@ -26,17 +28,13 @@ final class VatInfoResponse implements ResponseContract
     ) {}
 
     /**
-     * @param  array{vat_number?: string|null, tax_refnumber?: string|null}  $attributes
+     * @param  array<array-key, mixed>  $attributes
      */
     public static function from(array $attributes): self
     {
         return new self(
-            isset($attributes['vat_number']) && $attributes['vat_number'] !== ''
-                ? (string) $attributes['vat_number']
-                : null,
-            isset($attributes['tax_refnumber']) && $attributes['tax_refnumber'] !== ''
-                ? (string) $attributes['tax_refnumber']
-                : null,
+            self::stringOrNull($attributes['vat_number'] ?? null),
+            self::stringOrNull($attributes['tax_refnumber'] ?? null),
         );
     }
 

--- a/src/Transporters/HttpTransporter.php
+++ b/src/Transporters/HttpTransporter.php
@@ -66,6 +66,9 @@ final class HttpTransporter implements TransporterContract
         return Response::from($data);
     }
 
+    /**
+     * @param  Closure(): ResponseInterface  $callable
+     */
     private function sendRequest(Closure $callable): ResponseInterface
     {
         try {

--- a/src/ValueObjects/Transporter/Response.php
+++ b/src/ValueObjects/Transporter/Response.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace EFinancialsClient\ValueObjects\Transporter;
 
 /**
- * @template-covariant TData of array
+ * @template TData of array
  *
  * @internal
  */

--- a/tests/Client.php
+++ b/tests/Client.php
@@ -18,10 +18,9 @@ use EFinancialsClient\ValueObjects\ApiCredentials;
 use EFinancialsClient\ValueObjects\Transporter\BaseUri;
 use EFinancialsClient\ValueObjects\Transporter\Headers;
 use EFinancialsClient\ValueObjects\Transporter\Payload;
-use GuzzleHttp\Client as GuzzleClient;
-use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Psr7\Response;
+use Tests\Fakes\HttpClientFake;
+
+covers(Client::class, HttpTransporter::class, ApiCredentials::class);
 
 it('creates an auth key for a path', function () {
     $credentials = ApiCredentials::from('key-id', 'public-key', 'secret');
@@ -38,12 +37,10 @@ it('creates an auth key for a path', function () {
 });
 
 it('returns decoded json from a successful request', function () {
-    $mock = new MockHandler([
-        new Response(200, [], json_encode(['ok' => true], JSON_THROW_ON_ERROR)),
-    ]);
-
     $transporter = new HttpTransporter(
-        new GuzzleClient(['handler' => HandlerStack::create($mock)]),
+        HttpClientFake::sequence([
+            HttpClientFake::response(200, ['ok' => true]),
+        ]),
         BaseUri::from('https://demo-rmp-api.rik.ee'),
         Headers::create(),
         ApiCredentials::from('key-id', 'public-key', 'secret'),
@@ -55,12 +52,10 @@ it('returns decoded json from a successful request', function () {
 });
 
 it('throws a typed exception for http errors', function () {
-    $mock = new MockHandler([
-        new Response(401, [], 'Unauthorized'),
-    ]);
-
     $transporter = new HttpTransporter(
-        new GuzzleClient(['handler' => HandlerStack::create($mock)]),
+        HttpClientFake::sequence([
+            HttpClientFake::response(401, 'Unauthorized'),
+        ]),
         BaseUri::from('https://demo-rmp-api.rik.ee'),
         Headers::create(),
         ApiCredentials::from('key-id', 'public-key', 'secret'),
@@ -75,7 +70,7 @@ it('exposes resource accessors', function () {
         ->withApiKeyId('key-id')
         ->withApiKeyPublic('public-key')
         ->withApiKeyPassword('secret')
-        ->withHttpClient(new GuzzleClient(['handler' => HandlerStack::create(new MockHandler)]))
+        ->withHttpClient(HttpClientFake::sequence([]))
         ->make();
 
     expect($client->clients())->toBeInstanceOf(Clients::class)

--- a/tests/Fakes/HttpClientFake.php
+++ b/tests/Fakes/HttpClientFake.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fakes;
+
+use GuzzleHttp\Psr7\Response;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use RuntimeException;
+
+/**
+ * Queue-based PSR-18 client for unit tests.
+ */
+final class HttpClientFake implements ClientInterface
+{
+    /**
+     * @param  list<ResponseInterface>  $queue
+     */
+    public function __construct(private array $queue = []) {}
+
+    /**
+     * @param  list<ResponseInterface>  $responses
+     */
+    public static function sequence(array $responses): self
+    {
+        return new self(array_values($responses));
+    }
+
+    /**
+     * @param  array<array-key, mixed>|string  $body
+     * @param  array<string, string|array<int, string>>  $headers
+     */
+    public static function response(
+        int $status = 200,
+        array|string $body = '',
+        array $headers = [],
+    ): ResponseInterface {
+        if (is_array($body)) {
+            $body = json_encode($body, JSON_THROW_ON_ERROR);
+            $headers += ['Content-Type' => 'application/json'];
+        }
+
+        return new Response($status, $headers, $body);
+    }
+
+    public function sendRequest(RequestInterface $request): ResponseInterface
+    {
+        $response = array_shift($this->queue);
+
+        if (! $response instanceof ResponseInterface) {
+            throw new RuntimeException('HttpClientFake has no more queued responses.');
+        }
+
+        return $response;
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What:

- [ ] Bug Fix
- [ ] New Feature
- [x] Dependency / CI / tooling maintenance

### Description:

Follow-up that completes the earlier dependency bump by standardizing on **Pest 5** and applying the proposed tooling refactors.

#### Dependency / Pest 5
- `pestphp/pest` (+ arch/type-coverage/mutate plugins) → `^5.0` only (dropped Pest 3/4)
- `guzzlehttp/guzzle` → `^8.0.1`, plus direct `guzzlehttp/psr7` `^3.0` for response fixtures
- `symfony/var-dumper` → `^8.1.2`
- `psr/http-message` → `^2.0.0` only
- Added `phpstan/phpstan-strict-rules` + `phpstan/phpstan-deprecation-rules`
- Added `cweagans/composer-patches` for a temporary mutate plugin fix

#### Tooling refactors
1. **Mutation testing** — `composer test:mutate` (`--everything --covered-only --min=20`) + CI `mutate` job with PCOV. Includes a local patch for [pestphp/pest#1790](https://github.com/pestphp/pest/issues/1790) until upstream merges the coverage-php 14 fix.
2. **PSR-18 fake** — `Tests\Fakes\HttpClientFake` replaces Guzzle `MockHandler` / `HandlerStack` in unit tests.
3. **PHPStan `phpVersion: 80200`** — analysis tracks the library’s `^8.2` floor while CI runs on 8.4+.
4. **Bleeding edge + strict + deprecation rules** enabled in `phpstan.neon.dist`.
5. **`psr/http-message` narrowed to `^2.0`**.
6. **CI matrix** — tests on PHP 8.4/8.5 only (no Pest version matrix).

#### Supporting code changes for PHPStan max + strict
- `ResponseContract::offsetSet` accepts `null` offsets (ArrayAccess LSP)
- Factory base URI uses an explicit null/empty check (no short ternary)
- Extracted `NormalizesAttributes` for safe decoding of mixed API payloads

Verified locally: `composer test`, prefer-lowest types/unit, and mutation score ~22% (threshold 20).

### Related:

N/A — maintenance / tooling.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc2b9-81fc-766d-86fa-08e3558de996?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc2b9-81fc-766d-86fa-08e3558de996&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

