### PR TITLE
feat: add ApiFile and flat classifier response DTOs

### DIFF
--- a/src/Resources/AccountDimensions.php
+++ b/src/Resources/AccountDimensions.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace EFinancialsClient\Resources;
 
 use EFinancialsClient\Resources\Concerns\Transportable;
+use EFinancialsClient\Responses\AccountDimensions\ListResponse;
 use EFinancialsClient\ValueObjects\Transporter\Payload;
+use EFinancialsClient\ValueObjects\Transporter\Response;
 
 final class AccountDimensions
 {
@@ -16,12 +18,16 @@ final class AccountDimensions
      *
      * @see https://rmp-api.rik.ee/api.html#operation/get-account_dimensions
      */
-    public function all(): mixed
+    public function all(): ListResponse
     {
-
         $payload = Payload::get('account_dimensions');
+
+        /** @var Response<array<int, array<array-key, mixed>>> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        /** @var array<int, array<array-key, mixed>> $data */
+        $data = $response->data();
+
+        return ListResponse::from($data);
     }
 }

--- a/src/Resources/Accounts.php
+++ b/src/Resources/Accounts.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace EFinancialsClient\Resources;
 
 use EFinancialsClient\Resources\Concerns\Transportable;
+use EFinancialsClient\Responses\Accounts\ListResponse;
 use EFinancialsClient\ValueObjects\Transporter\Payload;
+use EFinancialsClient\ValueObjects\Transporter\Response;
 
 final class Accounts
 {
@@ -16,12 +18,16 @@ final class Accounts
      *
      * @see https://rmp-api.rik.ee/api.html#operation/get-accounts
      */
-    public function all(): mixed
+    public function all(): ListResponse
     {
-
         $payload = Payload::get('accounts');
+
+        /** @var Response<array<int, array<array-key, mixed>>> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        /** @var array<int, array<array-key, mixed>> $data */
+        $data = $response->data();
+
+        return ListResponse::from($data);
     }
 }

--- a/src/Resources/Bank.php
+++ b/src/Resources/Bank.php
@@ -5,9 +5,13 @@ declare(strict_types=1);
 namespace EFinancialsClient\Resources;
 
 use EFinancialsClient\Resources\Concerns\Transportable;
+use EFinancialsClient\Responses\ApiResponse;
+use EFinancialsClient\Responses\Bank\BankAccountResponse;
+use EFinancialsClient\Responses\Bank\ListResponse;
 use EFinancialsClient\Responses\VatInfo\VatInfoResponse;
 use EFinancialsClient\ValueObjects\Transporter\Payload;
 use EFinancialsClient\ValueObjects\Transporter\Response;
+use InvalidArgumentException;
 
 final class Bank
 {
@@ -18,13 +22,17 @@ final class Bank
      *
      * @see https://rmp-api.rik.ee/api.html#operation/get-bank_accounts
      */
-    public function all(): mixed
+    public function all(): ListResponse
     {
-
         $payload = Payload::get('bank_accounts');
+
+        /** @var Response<array<int, array<array-key, mixed>>> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        /** @var array<int, array<array-key, mixed>> $data */
+        $data = $response->data();
+
+        return ListResponse::from($data);
     }
 
     /**
@@ -32,13 +40,14 @@ final class Bank
      *
      * @see https://rmp-api.rik.ee/api.html#operation/get-bank_accounts_one
      */
-    public function get(int $id): mixed
+    public function get(int $id): BankAccountResponse
     {
-
         $payload = Payload::get('bank_accounts/'.$id);
+
+        /** @var Response<array<array-key, mixed>> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return BankAccountResponse::from($response->data());
     }
 
     /**
@@ -46,27 +55,9 @@ final class Bank
      *
      * @see https://rmp-api.rik.ee/api.html#operation/post-bank_accounts
      *
-     * @param array<string,mixed>|array{
-     *  "account_name_eng": "Swedbank AS EE123456780012345678",
-     *  "account_name_est": "Swedbank AS EE123456780012345678",
-     *  "account_no": "EE123456780012345678",
-     *  "accounts_dimensions_id": 2,
-     *  "bank_name": null,
-     *  "bank_regcode": null,
-     *  "beneficiary_name": null,
-     *  "cl_banks_id": 1,
-     *  "clients_id": 56,
-     *  "credit_limit": null,
-     *  "day_limit": null,
-     *  "default_salary_account": true,
-     *  "iban_code": "EE123456780012345678",
-     *  "id": 16,
-     *  "show_in_sale_invoices": true,
-     *  "start_sum": null,
-     *  "swift_code": "HABAEE2X"
-     * } $parameters
+     * @param  array<string, mixed>  $parameters
      */
-    public function create(array $parameters = []): mixed
+    public function create(array $parameters = []): ApiResponse
     {
         $missingRequiredParameters = array_diff_key(
             array_flip(
@@ -81,15 +72,17 @@ final class Bank
         if (count($missingRequiredParameters) !== 0) {
             $missingKeys = implode(', ', array_keys($missingRequiredParameters));
 
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 "Missing required parameter(s): $missingKeys"
             );
         }
 
         $payload = Payload::post('bank_accounts', $parameters);
+
+        /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return ApiResponse::from($response->data());
     }
 
     /**
@@ -97,29 +90,10 @@ final class Bank
      *
      * @see https://rmp-api.rik.ee/api.html#operation/patch-bank_accounts_one
      *
-     * @param array<string,mixed>|array{
-     *  "account_name_eng": "Swedbank AS EE123456780012345678",
-     *  "account_name_est": "Swedbank AS EE123456780012345678",
-     *  "account_no": "EE123456780012345678",
-     *  "accounts_dimensions_id": 2,
-     *  "bank_name": null,
-     *  "bank_regcode": null,
-     *  "beneficiary_name": null,
-     *  "cl_banks_id": 1,
-     *  "clients_id": 56,
-     *  "credit_limit": null,
-     *  "day_limit": null,
-     *  "default_salary_account": true,
-     *  "iban_code": "EE123456780012345678",
-     *  "id": 16,
-     *  "show_in_sale_invoices": true,
-     *  "start_sum": null,
-     *  "swift_code": "HABAEE2X"
-     * } $parameters
+     * @param  array<string, mixed>  $parameters
      */
-    public function update(int $id, array $parameters): mixed
+    public function update(int $id, array $parameters): ApiResponse
     {
-
         $missingParameters = array_diff_key(
             array_flip(
                 [
@@ -133,30 +107,34 @@ final class Bank
         if (count($missingParameters) !== 0) {
             $missingKeys = implode(', ', array_keys($missingParameters));
 
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 "Missing required parameter(s): $missingKeys"
             );
         }
 
         $payload = Payload::patch('bank_accounts/'.$id, $parameters);
+
+        /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return ApiResponse::from($response->data());
     }
 
     /**
      * Delete one specific bank account of the specified company.
      *
-     * @see https://rmp-api.rik.ee/api.html#operation/patch-bank_accounts_one
+     * @see https://rmp-api.rik.ee/api.html#operation/delete-bank_accounts_one
      *
      * @param  int  $id  Bank account identificator.
      */
-    public function delete(int $id): mixed
+    public function delete(int $id): ApiResponse
     {
         $payload = Payload::delete('bank_accounts/'.$id);
+
+        /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return ApiResponse::from($response->data());
     }
 
     /**

--- a/src/Resources/CostProfitCentres.php
+++ b/src/Resources/CostProfitCentres.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace EFinancialsClient\Resources;
 
 use DateTime;
+use DateTimeInterface;
 use EFinancialsClient\Resources\Concerns\Transportable;
+use EFinancialsClient\Responses\CostProfitCentres\ListResponse;
 use EFinancialsClient\ValueObjects\Transporter\Payload;
+use EFinancialsClient\ValueObjects\Transporter\Response;
 
 final class CostProfitCentres
 {
@@ -20,7 +23,7 @@ final class CostProfitCentres
      * @param  int  $page  Page of responses to return.
      * @param  DateTime|string  $modifiedSince  Return only objects modified since provided timestamp.
      */
-    public function all(int $page = 1, DateTime|string $modifiedSince = ''): mixed
+    public function all(int $page = 1, DateTime|string $modifiedSince = ''): ListResponse
     {
         $query = [];
 
@@ -30,13 +33,15 @@ final class CostProfitCentres
 
         if ($modifiedSince !== '') {
             $query['modified_since'] = ($modifiedSince instanceof DateTime)
-                ? $modifiedSince->format(\DateTimeInterface::ATOM)
+                ? $modifiedSince->format(DateTimeInterface::ATOM)
                 : $modifiedSince;
         }
 
         $payload = Payload::get('projects', $query);
+
+        /** @var Response<array{current_page: int, total_pages: int, items: array<int, array<array-key, mixed>>}> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return ListResponse::from($response->data());
     }
 }

--- a/src/Resources/PurchaseArticles.php
+++ b/src/Resources/PurchaseArticles.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace EFinancialsClient\Resources;
 
 use EFinancialsClient\Resources\Concerns\Transportable;
+use EFinancialsClient\Responses\PurchaseArticles\ListResponse;
 use EFinancialsClient\ValueObjects\Transporter\Payload;
+use EFinancialsClient\ValueObjects\Transporter\Response;
 
 final class PurchaseArticles
 {
@@ -16,12 +18,16 @@ final class PurchaseArticles
      *
      * @see https://rmp-api.rik.ee/api.html#operation/get-purchase_articles
      */
-    public function all(): mixed
+    public function all(): ListResponse
     {
-
         $payload = Payload::get('purchase_articles');
+
+        /** @var Response<array<int, array<array-key, mixed>>> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        /** @var array<int, array<array-key, mixed>> $data */
+        $data = $response->data();
+
+        return ListResponse::from($data);
     }
 }

--- a/src/Resources/SalesArticles.php
+++ b/src/Resources/SalesArticles.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace EFinancialsClient\Resources;
 
 use EFinancialsClient\Resources\Concerns\Transportable;
+use EFinancialsClient\Responses\SalesArticles\ListResponse;
 use EFinancialsClient\ValueObjects\Transporter\Payload;
+use EFinancialsClient\ValueObjects\Transporter\Response;
 
 final class SalesArticles
 {
@@ -16,12 +18,16 @@ final class SalesArticles
      *
      * @see https://rmp-api.rik.ee/api.html#operation/get-sale_articles
      */
-    public function all(): mixed
+    public function all(): ListResponse
     {
-
         $payload = Payload::get('sale_articles');
+
+        /** @var Response<array<int, array<array-key, mixed>>> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        /** @var array<int, array<array-key, mixed>> $data */
+        $data = $response->data();
+
+        return ListResponse::from($data);
     }
 }

--- a/src/Responses/AccountDimensions/AccountDimensionResponse.php
+++ b/src/Responses/AccountDimensions/AccountDimensionResponse.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Responses\AccountDimensions;
+
+use EFinancialsClient\Contracts\ResponseContract;
+use EFinancialsClient\Responses\Concerns\ArrayAccessible;
+use EFinancialsClient\Responses\Concerns\NormalizesAttributes;
+use EFinancialsClient\Testing\Responses\Concerns\Fakeable;
+
+/**
+ * Full projection of the OpenAPI `AccountsDimensions` schema
+ * (plus selected example-backed fields omitted from `properties`).
+ *
+ * @see https://rmp-api.rik.ee/openapi.yaml
+ *
+ * @phpstan-type AccountDimensionData array{
+ *     id: int|null,
+ *     accounts_id: int,
+ *     title_est: string,
+ *     title_eng: string|null,
+ *     cl_currencies_id: string|null,
+ *     is_deleted: bool|null,
+ *     expenditure_accounts_dimensions_id: string|null,
+ *     amortization_accounts_dimensions_id: string|null
+ * }
+ *
+ * @implements ResponseContract<AccountDimensionData>
+ */
+final class AccountDimensionResponse implements ResponseContract
+{
+    /**
+     * @use ArrayAccessible<AccountDimensionData>
+     */
+    use ArrayAccessible;
+
+    use Fakeable;
+    use NormalizesAttributes;
+
+    private function __construct(
+        public readonly ?int $id,
+        public readonly int $accountsId,
+        public readonly string $titleEst,
+        public readonly ?string $titleEng,
+        public readonly ?string $clCurrenciesId,
+        public readonly ?bool $isDeleted,
+        public readonly ?string $expenditureAccountsDimensionsId,
+        public readonly ?string $amortizationAccountsDimensionsId,
+    ) {}
+
+    /**
+     * @param  array<array-key, mixed>  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            self::intOrNull($attributes['id'] ?? null),
+            self::intValue($attributes['accounts_id'] ?? null),
+            self::stringValue($attributes['title_est'] ?? null),
+            self::stringOrNull($attributes['title_eng'] ?? null),
+            self::stringOrNull($attributes['cl_currencies_id'] ?? null),
+            self::boolOrNull($attributes['is_deleted'] ?? null),
+            self::stringOrNull($attributes['expenditure_accounts_dimensions_id'] ?? null),
+            self::stringOrNull($attributes['amortization_accounts_dimensions_id'] ?? null),
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'accounts_id' => $this->accountsId,
+            'title_est' => $this->titleEst,
+            'title_eng' => $this->titleEng,
+            'cl_currencies_id' => $this->clCurrenciesId,
+            'is_deleted' => $this->isDeleted,
+            'expenditure_accounts_dimensions_id' => $this->expenditureAccountsDimensionsId,
+            'amortization_accounts_dimensions_id' => $this->amortizationAccountsDimensionsId,
+        ];
+    }
+}

--- a/src/Responses/AccountDimensions/ListResponse.php
+++ b/src/Responses/AccountDimensions/ListResponse.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Responses\AccountDimensions;
+
+use EFinancialsClient\Contracts\ResponseContract;
+use EFinancialsClient\Responses\Concerns\ArrayAccessible;
+use EFinancialsClient\Testing\Responses\Concerns\Fakeable;
+
+/**
+ * @phpstan-import-type AccountDimensionData from AccountDimensionResponse
+ *
+ * @implements ResponseContract<array<int, AccountDimensionData>>
+ */
+final class ListResponse implements ResponseContract
+{
+    /**
+     * @use ArrayAccessible<array<int, AccountDimensionData>>
+     */
+    use ArrayAccessible;
+
+    use Fakeable;
+
+    /**
+     * @param  array<int, AccountDimensionResponse>  $data
+     */
+    private function __construct(public readonly array $data)
+    {
+        // ..
+    }
+
+    /**
+     * @param  array<int, array<array-key, mixed>>  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        $data = array_map(
+            static fn (array $item): AccountDimensionResponse => AccountDimensionResponse::from($item),
+            array_values($attributes),
+        );
+
+        return new self($data);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toArray(): array
+    {
+        return array_map(
+            static fn (AccountDimensionResponse $item): array => $item->toArray(),
+            $this->data,
+        );
+    }
+}

--- a/src/Responses/Accounts/AccountResponse.php
+++ b/src/Responses/Accounts/AccountResponse.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Responses\Accounts;
+
+use EFinancialsClient\Contracts\ResponseContract;
+use EFinancialsClient\Responses\Concerns\ArrayAccessible;
+use EFinancialsClient\Responses\Concerns\NormalizesAttributes;
+use EFinancialsClient\Testing\Responses\Concerns\Fakeable;
+
+/**
+ * Full projection of the OpenAPI `Accounts` schema
+ * (plus selected example-backed fields omitted from `properties`).
+ *
+ * @see https://rmp-api.rik.ee/openapi.yaml
+ *
+ * @phpstan-type AccountData array{
+ *     id: int|null,
+ *     balance_type: string,
+ *     account_type_est: string,
+ *     account_type_eng: string,
+ *     name_est: string,
+ *     name_eng: string,
+ *     is_valid: bool,
+ *     allows_deactivation: bool,
+ *     is_vat_account: bool,
+ *     is_fixed_asset: bool,
+ *     expenditure_accounts_id: int|null,
+ *     amortization_accounts_id: int|null,
+ *     transaction_in_bindable: bool,
+ *     transaction_out_bindable: bool,
+ *     priority: int|null,
+ *     cl_account_groups: array<int, string>,
+ *     default_disabled: bool,
+ *     transaction_in_user_bindable: bool,
+ *     transaction_out_user_bindable: bool,
+ *     is_product_account: bool,
+ *     allows_dimensions: bool|null,
+ *     requires_client: bool|null,
+ *     requires_positive_balance: bool|null,
+ *     is_disabled: bool|null,
+ *     transaction_in_user_bindable_set: bool|null,
+ *     transaction_out_user_bindable_set: bool|null
+ * }
+ *
+ * @implements ResponseContract<AccountData>
+ */
+final class AccountResponse implements ResponseContract
+{
+    /**
+     * @use ArrayAccessible<AccountData>
+     */
+    use ArrayAccessible;
+
+    use Fakeable;
+    use NormalizesAttributes;
+
+    /**
+     * @param  array<int, string>  $clAccountGroups
+     */
+    private function __construct(
+        public readonly ?int $id,
+        public readonly string $balanceType,
+        public readonly string $accountTypeEst,
+        public readonly string $accountTypeEng,
+        public readonly string $nameEst,
+        public readonly string $nameEng,
+        public readonly bool $isValid,
+        public readonly bool $allowsDeactivation,
+        public readonly bool $isVatAccount,
+        public readonly bool $isFixedAsset,
+        public readonly ?int $expenditureAccountsId,
+        public readonly ?int $amortizationAccountsId,
+        public readonly bool $transactionInBindable,
+        public readonly bool $transactionOutBindable,
+        public readonly ?int $priority,
+        public readonly array $clAccountGroups,
+        public readonly bool $defaultDisabled,
+        public readonly bool $transactionInUserBindable,
+        public readonly bool $transactionOutUserBindable,
+        public readonly bool $isProductAccount,
+        public readonly ?bool $allowsDimensions,
+        public readonly ?bool $requiresClient,
+        public readonly ?bool $requiresPositiveBalance,
+        public readonly ?bool $isDisabled,
+        public readonly ?bool $transactionInUserBindableSet,
+        public readonly ?bool $transactionOutUserBindableSet,
+    ) {}
+
+    /**
+     * @param  array<array-key, mixed>  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            self::intOrNull($attributes['id'] ?? null),
+            self::stringValue($attributes['balance_type'] ?? null),
+            self::stringValue($attributes['account_type_est'] ?? null),
+            self::stringValue($attributes['account_type_eng'] ?? null),
+            self::stringValue($attributes['name_est'] ?? null),
+            self::stringValue($attributes['name_eng'] ?? null),
+            self::boolValue($attributes['is_valid'] ?? null),
+            self::boolValue($attributes['allows_deactivation'] ?? null),
+            self::boolValue($attributes['is_vat_account'] ?? null),
+            self::boolValue($attributes['is_fixed_asset'] ?? null),
+            self::intOrNull($attributes['expenditure_accounts_id'] ?? null),
+            self::intOrNull($attributes['amortization_accounts_id'] ?? null),
+            self::boolValue($attributes['transaction_in_bindable'] ?? null),
+            self::boolValue($attributes['transaction_out_bindable'] ?? null),
+            self::intOrNull($attributes['priority'] ?? null),
+            self::stringList($attributes['cl_account_groups'] ?? null),
+            self::boolValue($attributes['default_disabled'] ?? null),
+            self::boolValue($attributes['transaction_in_user_bindable'] ?? null),
+            self::boolValue($attributes['transaction_out_user_bindable'] ?? null),
+            self::boolValue($attributes['is_product_account'] ?? null),
+            self::boolOrNull($attributes['allows_dimensions'] ?? null),
+            self::boolOrNull($attributes['requires_client'] ?? null),
+            self::boolOrNull($attributes['requires_positive_balance'] ?? null),
+            self::boolOrNull($attributes['is_disabled'] ?? null),
+            self::boolOrNull($attributes['transaction_in_user_bindable_set'] ?? null),
+            self::boolOrNull($attributes['transaction_out_user_bindable_set'] ?? null),
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'balance_type' => $this->balanceType,
+            'account_type_est' => $this->accountTypeEst,
+            'account_type_eng' => $this->accountTypeEng,
+            'name_est' => $this->nameEst,
+            'name_eng' => $this->nameEng,
+            'is_valid' => $this->isValid,
+            'allows_deactivation' => $this->allowsDeactivation,
+            'is_vat_account' => $this->isVatAccount,
+            'is_fixed_asset' => $this->isFixedAsset,
+            'expenditure_accounts_id' => $this->expenditureAccountsId,
+            'amortization_accounts_id' => $this->amortizationAccountsId,
+            'transaction_in_bindable' => $this->transactionInBindable,
+            'transaction_out_bindable' => $this->transactionOutBindable,
+            'priority' => $this->priority,
+            'cl_account_groups' => $this->clAccountGroups,
+            'default_disabled' => $this->defaultDisabled,
+            'transaction_in_user_bindable' => $this->transactionInUserBindable,
+            'transaction_out_user_bindable' => $this->transactionOutUserBindable,
+            'is_product_account' => $this->isProductAccount,
+            'allows_dimensions' => $this->allowsDimensions,
+            'requires_client' => $this->requiresClient,
+            'requires_positive_balance' => $this->requiresPositiveBalance,
+            'is_disabled' => $this->isDisabled,
+            'transaction_in_user_bindable_set' => $this->transactionInUserBindableSet,
+            'transaction_out_user_bindable_set' => $this->transactionOutUserBindableSet,
+        ];
+    }
+}

--- a/src/Responses/Accounts/ListResponse.php
+++ b/src/Responses/Accounts/ListResponse.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Responses\Accounts;
+
+use EFinancialsClient\Contracts\ResponseContract;
+use EFinancialsClient\Responses\Concerns\ArrayAccessible;
+use EFinancialsClient\Testing\Responses\Concerns\Fakeable;
+
+/**
+ * @phpstan-import-type AccountData from AccountResponse
+ *
+ * @implements ResponseContract<array<int, AccountData>>
+ */
+final class ListResponse implements ResponseContract
+{
+    /**
+     * @use ArrayAccessible<array<int, AccountData>>
+     */
+    use ArrayAccessible;
+
+    use Fakeable;
+
+    /**
+     * @param  array<int, AccountResponse>  $data
+     */
+    private function __construct(public readonly array $data)
+    {
+        // ..
+    }
+
+    /**
+     * @param  array<int, array<array-key, mixed>>  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        $data = array_map(
+            static fn (array $item): AccountResponse => AccountResponse::from($item),
+            array_values($attributes),
+        );
+
+        return new self($data);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toArray(): array
+    {
+        return array_map(
+            static fn (AccountResponse $item): array => $item->toArray(),
+            $this->data,
+        );
+    }
+}

--- a/src/Responses/ApiFileResponse.php
+++ b/src/Responses/ApiFileResponse.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Responses;
+
+use EFinancialsClient\Contracts\ResponseContract;
+use EFinancialsClient\Responses\Concerns\ArrayAccessible;
+use EFinancialsClient\Responses\Concerns\NormalizesAttributes;
+use EFinancialsClient\Testing\Responses\Concerns\Fakeable;
+
+/**
+ * Full projection of the OpenAPI `ApiFile` schema.
+ *
+ * @see https://rmp-api.rik.ee/openapi.yaml
+ *
+ * @phpstan-type ApiFileData array{name: string, contents: string}
+ *
+ * @implements ResponseContract<ApiFileData>
+ */
+final class ApiFileResponse implements ResponseContract
+{
+    /**
+     * @use ArrayAccessible<ApiFileData>
+     */
+    use ArrayAccessible;
+
+    use Fakeable;
+    use NormalizesAttributes;
+
+    private function __construct(
+        public readonly string $name,
+        public readonly string $contents,
+    ) {}
+
+    /**
+     * @param  array<array-key, mixed>  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            self::stringValue($attributes['name'] ?? null),
+            self::stringValue($attributes['contents'] ?? null),
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toArray(): array
+    {
+        return [
+            'name' => $this->name,
+            'contents' => $this->contents,
+        ];
+    }
+}

--- a/src/Responses/Bank/BankAccountResponse.php
+++ b/src/Responses/Bank/BankAccountResponse.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Responses\Bank;
+
+use EFinancialsClient\Contracts\ResponseContract;
+use EFinancialsClient\Responses\Concerns\ArrayAccessible;
+use EFinancialsClient\Responses\Concerns\NormalizesAttributes;
+use EFinancialsClient\Testing\Responses\Concerns\Fakeable;
+
+/**
+ * Full projection of the OpenAPI `BankAccounts` schema
+ * (plus selected example-backed fields omitted from `properties`).
+ *
+ * @see https://rmp-api.rik.ee/openapi.yaml
+ *
+ * @phpstan-type BankAccountData array{
+ *     id: int|null,
+ *     account_name_est: string,
+ *     account_name_eng: string|null,
+ *     account_no: string,
+ *     cl_banks_id: int|null,
+ *     bank_name: string|null,
+ *     bank_regcode: string|null,
+ *     iban_code: string|null,
+ *     swift_code: string|null,
+ *     start_sum: float|null,
+ *     day_limit: float|null,
+ *     credit_limit: float|null,
+ *     show_in_sale_invoices: bool|null,
+ *     default_salary_account: bool|null,
+ *     beneficiary_name: string|null,
+ *     accounts_dimensions_id: int|null,
+ *     clients_id: int|null
+ * }
+ *
+ * @implements ResponseContract<BankAccountData>
+ */
+final class BankAccountResponse implements ResponseContract
+{
+    /**
+     * @use ArrayAccessible<BankAccountData>
+     */
+    use ArrayAccessible;
+
+    use Fakeable;
+    use NormalizesAttributes;
+
+    private function __construct(
+        public readonly ?int $id,
+        public readonly string $accountNameEst,
+        public readonly ?string $accountNameEng,
+        public readonly string $accountNo,
+        public readonly ?int $clBanksId,
+        public readonly ?string $bankName,
+        public readonly ?string $bankRegcode,
+        public readonly ?string $ibanCode,
+        public readonly ?string $swiftCode,
+        public readonly ?float $startSum,
+        public readonly ?float $dayLimit,
+        public readonly ?float $creditLimit,
+        public readonly ?bool $showInSaleInvoices,
+        public readonly ?bool $defaultSalaryAccount,
+        public readonly ?string $beneficiaryName,
+        public readonly ?int $accountsDimensionsId,
+        public readonly ?int $clientsId,
+    ) {}
+
+    /**
+     * @param  array<array-key, mixed>  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            self::intOrNull($attributes['id'] ?? null),
+            self::stringValue($attributes['account_name_est'] ?? null),
+            self::stringOrNull($attributes['account_name_eng'] ?? null),
+            self::stringValue($attributes['account_no'] ?? null),
+            self::intOrNull($attributes['cl_banks_id'] ?? null),
+            self::stringOrNull($attributes['bank_name'] ?? null),
+            self::stringOrNull($attributes['bank_regcode'] ?? null),
+            self::stringOrNull($attributes['iban_code'] ?? null),
+            self::stringOrNull($attributes['swift_code'] ?? null),
+            self::floatOrNull($attributes['start_sum'] ?? null),
+            self::floatOrNull($attributes['day_limit'] ?? null),
+            self::floatOrNull($attributes['credit_limit'] ?? null),
+            self::boolOrNull($attributes['show_in_sale_invoices'] ?? null),
+            self::boolOrNull($attributes['default_salary_account'] ?? null),
+            self::stringOrNull($attributes['beneficiary_name'] ?? null),
+            self::intOrNull($attributes['accounts_dimensions_id'] ?? null),
+            self::intOrNull($attributes['clients_id'] ?? null),
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'account_name_est' => $this->accountNameEst,
+            'account_name_eng' => $this->accountNameEng,
+            'account_no' => $this->accountNo,
+            'cl_banks_id' => $this->clBanksId,
+            'bank_name' => $this->bankName,
+            'bank_regcode' => $this->bankRegcode,
+            'iban_code' => $this->ibanCode,
+            'swift_code' => $this->swiftCode,
+            'start_sum' => $this->startSum,
+            'day_limit' => $this->dayLimit,
+            'credit_limit' => $this->creditLimit,
+            'show_in_sale_invoices' => $this->showInSaleInvoices,
+            'default_salary_account' => $this->defaultSalaryAccount,
+            'beneficiary_name' => $this->beneficiaryName,
+            'accounts_dimensions_id' => $this->accountsDimensionsId,
+            'clients_id' => $this->clientsId,
+        ];
+    }
+}

--- a/src/Responses/Bank/ListResponse.php
+++ b/src/Responses/Bank/ListResponse.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Responses\Bank;
+
+use EFinancialsClient\Contracts\ResponseContract;
+use EFinancialsClient\Responses\Concerns\ArrayAccessible;
+use EFinancialsClient\Testing\Responses\Concerns\Fakeable;
+
+/**
+ * @phpstan-import-type BankAccountData from BankAccountResponse
+ *
+ * @implements ResponseContract<array<int, BankAccountData>>
+ */
+final class ListResponse implements ResponseContract
+{
+    /**
+     * @use ArrayAccessible<array<int, BankAccountData>>
+     */
+    use ArrayAccessible;
+
+    use Fakeable;
+
+    /**
+     * @param  array<int, BankAccountResponse>  $data
+     */
+    private function __construct(public readonly array $data)
+    {
+        // ..
+    }
+
+    /**
+     * @param  array<int, array<array-key, mixed>>  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        $data = array_map(
+            static fn (array $item): BankAccountResponse => BankAccountResponse::from($item),
+            array_values($attributes),
+        );
+
+        return new self($data);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toArray(): array
+    {
+        return array_map(
+            static fn (BankAccountResponse $item): array => $item->toArray(),
+            $this->data,
+        );
+    }
+}

--- a/src/Responses/Concerns/NormalizesAttributes.php
+++ b/src/Responses/Concerns/NormalizesAttributes.php
@@ -91,4 +91,28 @@ trait NormalizesAttributes
     {
         return self::boolOrNull($value) ?? $default;
     }
+
+    /**
+     * @return array<int, string>
+     */
+    private static function stringList(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        $list = [];
+
+        foreach ($value as $item) {
+            $string = self::stringOrNull($item);
+
+            if ($string === null) {
+                continue;
+            }
+
+            $list[] = $string;
+        }
+
+        return $list;
+    }
 }

--- a/src/Responses/CostProfitCentres/CostProfitCentreResponse.php
+++ b/src/Responses/CostProfitCentres/CostProfitCentreResponse.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Responses\CostProfitCentres;
+
+use EFinancialsClient\Contracts\ResponseContract;
+use EFinancialsClient\Responses\Concerns\ArrayAccessible;
+use EFinancialsClient\Responses\Concerns\NormalizesAttributes;
+use EFinancialsClient\Testing\Responses\Concerns\Fakeable;
+
+/**
+ * Full projection of the OpenAPI `Projects` schema
+ * (plus selected example-backed fields omitted from `properties`).
+ *
+ * @see https://rmp-api.rik.ee/openapi.yaml
+ *
+ * @phpstan-type CostProfitCentreData array{
+ *     id: int|null,
+ *     parent_id: int|null,
+ *     name: string,
+ *     notes: string|null,
+ *     cl_projects_type: string,
+ *     is_disabled: bool,
+ *     create_date: string|null,
+ *     deprecated_parent_id: int|null,
+ *     is_deleted: bool|null
+ * }
+ *
+ * @implements ResponseContract<CostProfitCentreData>
+ */
+final class CostProfitCentreResponse implements ResponseContract
+{
+    /**
+     * @use ArrayAccessible<CostProfitCentreData>
+     */
+    use ArrayAccessible;
+
+    use Fakeable;
+    use NormalizesAttributes;
+
+    private function __construct(
+        public readonly ?int $id,
+        public readonly ?int $parentId,
+        public readonly string $name,
+        public readonly ?string $notes,
+        public readonly string $clProjectsType,
+        public readonly bool $isDisabled,
+        public readonly ?string $createDate,
+        public readonly ?int $deprecatedParentId,
+        public readonly ?bool $isDeleted,
+    ) {}
+
+    /**
+     * @param  array<array-key, mixed>  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            self::intOrNull($attributes['id'] ?? null),
+            self::intOrNull($attributes['parent_id'] ?? null),
+            self::stringValue($attributes['name'] ?? null),
+            self::stringOrNull($attributes['notes'] ?? null),
+            self::stringValue($attributes['cl_projects_type'] ?? null),
+            self::boolValue($attributes['is_disabled'] ?? null),
+            self::stringOrNull($attributes['create_date'] ?? null),
+            self::intOrNull($attributes['deprecated_parent_id'] ?? null),
+            self::boolOrNull($attributes['is_deleted'] ?? null),
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'parent_id' => $this->parentId,
+            'name' => $this->name,
+            'notes' => $this->notes,
+            'cl_projects_type' => $this->clProjectsType,
+            'is_disabled' => $this->isDisabled,
+            'create_date' => $this->createDate,
+            'deprecated_parent_id' => $this->deprecatedParentId,
+            'is_deleted' => $this->isDeleted,
+        ];
+    }
+}

--- a/src/Responses/CostProfitCentres/ListResponse.php
+++ b/src/Responses/CostProfitCentres/ListResponse.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Responses\CostProfitCentres;
+
+use EFinancialsClient\Contracts\ResponseContract;
+use EFinancialsClient\Responses\Concerns\ArrayAccessible;
+use EFinancialsClient\Responses\Concerns\NormalizesAttributes;
+use EFinancialsClient\Testing\Responses\Concerns\Fakeable;
+
+/**
+ * @phpstan-import-type CostProfitCentreData from CostProfitCentreResponse
+ *
+ * @implements ResponseContract<array{current_page: int, total_pages: int, items: array<int, CostProfitCentreData>}>
+ */
+final class ListResponse implements ResponseContract
+{
+    /**
+     * @use ArrayAccessible<array{current_page: int, total_pages: int, items: array<int, CostProfitCentreData>}>
+     */
+    use ArrayAccessible;
+
+    use Fakeable;
+    use NormalizesAttributes;
+
+    /**
+     * @param  array<int, CostProfitCentreResponse>  $items
+     */
+    private function __construct(
+        public readonly int $currentPage,
+        public readonly int $totalPages,
+        public readonly array $items,
+    ) {}
+
+    /**
+     * @param  array<array-key, mixed>  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        /** @var array<int, array<string, mixed>> $rawItems */
+        $rawItems = is_array($attributes['items'] ?? null) ? $attributes['items'] : [];
+
+        $items = array_map(
+            static fn (array $item): CostProfitCentreResponse => CostProfitCentreResponse::from($item),
+            $rawItems,
+        );
+
+        return new self(
+            self::intValue($attributes['current_page'] ?? 0),
+            self::intValue($attributes['total_pages'] ?? 0),
+            $items,
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toArray(): array
+    {
+        return [
+            'current_page' => $this->currentPage,
+            'total_pages' => $this->totalPages,
+            'items' => array_map(
+                static fn (CostProfitCentreResponse $item): array => $item->toArray(),
+                $this->items,
+            ),
+        ];
+    }
+}

--- a/src/Responses/PurchaseArticles/ListResponse.php
+++ b/src/Responses/PurchaseArticles/ListResponse.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Responses\PurchaseArticles;
+
+use EFinancialsClient\Contracts\ResponseContract;
+use EFinancialsClient\Responses\Concerns\ArrayAccessible;
+use EFinancialsClient\Testing\Responses\Concerns\Fakeable;
+
+/**
+ * @phpstan-import-type PurchaseArticleData from PurchaseArticleResponse
+ *
+ * @implements ResponseContract<array<int, PurchaseArticleData>>
+ */
+final class ListResponse implements ResponseContract
+{
+    /**
+     * @use ArrayAccessible<array<int, PurchaseArticleData>>
+     */
+    use ArrayAccessible;
+
+    use Fakeable;
+
+    /**
+     * @param  array<int, PurchaseArticleResponse>  $data
+     */
+    private function __construct(public readonly array $data)
+    {
+        // ..
+    }
+
+    /**
+     * @param  array<int, array<array-key, mixed>>  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        $data = array_map(
+            static fn (array $item): PurchaseArticleResponse => PurchaseArticleResponse::from($item),
+            array_values($attributes),
+        );
+
+        return new self($data);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toArray(): array
+    {
+        return array_map(
+            static fn (PurchaseArticleResponse $item): array => $item->toArray(),
+            $this->data,
+        );
+    }
+}

--- a/src/Responses/PurchaseArticles/PurchaseArticleResponse.php
+++ b/src/Responses/PurchaseArticles/PurchaseArticleResponse.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Responses\PurchaseArticles;
+
+use EFinancialsClient\Contracts\ResponseContract;
+use EFinancialsClient\Responses\Concerns\ArrayAccessible;
+use EFinancialsClient\Responses\Concerns\NormalizesAttributes;
+use EFinancialsClient\Testing\Responses\Concerns\Fakeable;
+
+/**
+ * Full projection of the OpenAPI `PurchaseArticles` schema
+ * (plus selected example-backed fields omitted from `properties`).
+ *
+ * @see https://rmp-api.rik.ee/openapi.yaml
+ *
+ * @phpstan-type PurchaseArticleData array{
+ *     id: int|null,
+ *     level: int,
+ *     name_est: string,
+ *     name_eng: string,
+ *     accounts_id: int|null,
+ *     priority: int|null,
+ *     cl_account_groups: array<int, string>,
+ *     is_disabled: bool|null
+ * }
+ *
+ * @implements ResponseContract<PurchaseArticleData>
+ */
+final class PurchaseArticleResponse implements ResponseContract
+{
+    /**
+     * @use ArrayAccessible<PurchaseArticleData>
+     */
+    use ArrayAccessible;
+
+    use Fakeable;
+    use NormalizesAttributes;
+
+    /**
+     * @param  array<int, string>  $clAccountGroups
+     */
+    private function __construct(
+        public readonly ?int $id,
+        public readonly int $level,
+        public readonly string $nameEst,
+        public readonly string $nameEng,
+        public readonly ?int $accountsId,
+        public readonly ?int $priority,
+        public readonly array $clAccountGroups,
+        public readonly ?bool $isDisabled,
+    ) {}
+
+    /**
+     * @param  array<array-key, mixed>  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            self::intOrNull($attributes['id'] ?? null),
+            self::intValue($attributes['level'] ?? null),
+            self::stringValue($attributes['name_est'] ?? null),
+            self::stringValue($attributes['name_eng'] ?? null),
+            self::intOrNull($attributes['accounts_id'] ?? null),
+            self::intOrNull($attributes['priority'] ?? null),
+            self::stringList($attributes['cl_account_groups'] ?? null),
+            self::boolOrNull($attributes['is_disabled'] ?? null),
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'level' => $this->level,
+            'name_est' => $this->nameEst,
+            'name_eng' => $this->nameEng,
+            'accounts_id' => $this->accountsId,
+            'priority' => $this->priority,
+            'cl_account_groups' => $this->clAccountGroups,
+            'is_disabled' => $this->isDisabled,
+        ];
+    }
+}

--- a/src/Responses/SalesArticles/ListResponse.php
+++ b/src/Responses/SalesArticles/ListResponse.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Responses\SalesArticles;
+
+use EFinancialsClient\Contracts\ResponseContract;
+use EFinancialsClient\Responses\Concerns\ArrayAccessible;
+use EFinancialsClient\Testing\Responses\Concerns\Fakeable;
+
+/**
+ * @phpstan-import-type SalesArticleData from SalesArticleResponse
+ *
+ * @implements ResponseContract<array<int, SalesArticleData>>
+ */
+final class ListResponse implements ResponseContract
+{
+    /**
+     * @use ArrayAccessible<array<int, SalesArticleData>>
+     */
+    use ArrayAccessible;
+
+    use Fakeable;
+
+    /**
+     * @param  array<int, SalesArticleResponse>  $data
+     */
+    private function __construct(public readonly array $data)
+    {
+        // ..
+    }
+
+    /**
+     * @param  array<int, array<array-key, mixed>>  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        $data = array_map(
+            static fn (array $item): SalesArticleResponse => SalesArticleResponse::from($item),
+            array_values($attributes),
+        );
+
+        return new self($data);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toArray(): array
+    {
+        return array_map(
+            static fn (SalesArticleResponse $item): array => $item->toArray(),
+            $this->data,
+        );
+    }
+}

--- a/src/Responses/SalesArticles/SalesArticleResponse.php
+++ b/src/Responses/SalesArticles/SalesArticleResponse.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Responses\SalesArticles;
+
+use EFinancialsClient\Contracts\ResponseContract;
+use EFinancialsClient\Responses\Concerns\ArrayAccessible;
+use EFinancialsClient\Responses\Concerns\NormalizesAttributes;
+use EFinancialsClient\Testing\Responses\Concerns\Fakeable;
+
+/**
+ * Full projection of the OpenAPI `SaleArticles` schema
+ * (plus selected example-backed fields omitted from `properties`).
+ *
+ * @see https://rmp-api.rik.ee/openapi.yaml
+ *
+ * @phpstan-type SalesArticleData array{
+ *     id: int|null,
+ *     group_est: string,
+ *     group_eng: string,
+ *     name_est: string,
+ *     name_eng: string,
+ *     accounts_id: int,
+ *     vat_accounts_id: int|null,
+ *     vat_rate: float|null,
+ *     vat_type: int,
+ *     is_valid: bool,
+ *     start_date: string|null,
+ *     end_date: string|null,
+ *     priority: int|null,
+ *     cl_account_groups: array<int, string>,
+ *     description_est: string|null,
+ *     description_eng: string|null
+ * }
+ *
+ * @implements ResponseContract<SalesArticleData>
+ */
+final class SalesArticleResponse implements ResponseContract
+{
+    /**
+     * @use ArrayAccessible<SalesArticleData>
+     */
+    use ArrayAccessible;
+
+    use Fakeable;
+    use NormalizesAttributes;
+
+    /**
+     * @param  array<int, string>  $clAccountGroups
+     */
+    private function __construct(
+        public readonly ?int $id,
+        public readonly string $groupEst,
+        public readonly string $groupEng,
+        public readonly string $nameEst,
+        public readonly string $nameEng,
+        public readonly int $accountsId,
+        public readonly ?int $vatAccountsId,
+        public readonly ?float $vatRate,
+        public readonly int $vatType,
+        public readonly bool $isValid,
+        public readonly ?string $startDate,
+        public readonly ?string $endDate,
+        public readonly ?int $priority,
+        public readonly array $clAccountGroups,
+        public readonly ?string $descriptionEst,
+        public readonly ?string $descriptionEng,
+    ) {}
+
+    /**
+     * @param  array<array-key, mixed>  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            self::intOrNull($attributes['id'] ?? null),
+            self::stringValue($attributes['group_est'] ?? null),
+            self::stringValue($attributes['group_eng'] ?? null),
+            self::stringValue($attributes['name_est'] ?? null),
+            self::stringValue($attributes['name_eng'] ?? null),
+            self::intValue($attributes['accounts_id'] ?? null),
+            self::intOrNull($attributes['vat_accounts_id'] ?? null),
+            self::floatOrNull($attributes['vat_rate'] ?? null),
+            self::intValue($attributes['vat_type'] ?? null),
+            self::boolValue($attributes['is_valid'] ?? null),
+            self::stringOrNull($attributes['start_date'] ?? null),
+            self::stringOrNull($attributes['end_date'] ?? null),
+            self::intOrNull($attributes['priority'] ?? null),
+            self::stringList($attributes['cl_account_groups'] ?? null),
+            self::stringOrNull($attributes['description_est'] ?? null),
+            self::stringOrNull($attributes['description_eng'] ?? null),
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'group_est' => $this->groupEst,
+            'group_eng' => $this->groupEng,
+            'name_est' => $this->nameEst,
+            'name_eng' => $this->nameEng,
+            'accounts_id' => $this->accountsId,
+            'vat_accounts_id' => $this->vatAccountsId,
+            'vat_rate' => $this->vatRate,
+            'vat_type' => $this->vatType,
+            'is_valid' => $this->isValid,
+            'start_date' => $this->startDate,
+            'end_date' => $this->endDate,
+            'priority' => $this->priority,
+            'cl_account_groups' => $this->clAccountGroups,
+            'description_est' => $this->descriptionEst,
+            'description_eng' => $this->descriptionEng,
+        ];
+    }
+}

--- a/src/Testing/Responses/Fixtures/AccountDimensions/AccountDimensionResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/AccountDimensions/AccountDimensionResponseFixture.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Testing\Responses\Fixtures\AccountDimensions;
+
+/**
+ * OpenAPI `AccountsDimensions` schema example (fuller projection).
+ *
+ * @see https://rmp-api.rik.ee/openapi.yaml
+ */
+final class AccountDimensionResponseFixture
+{
+    /**
+     * @var array<string, mixed>
+     */
+    public const ATTRIBUTES = [
+        'id' => 1,
+        'accounts_id' => 1100,
+        'title_est' => 'Lühiajalised finantsinvesteeringud',
+        'title_eng' => 'Current financial investments',
+        'cl_currencies_id' => 'EUR',
+        'is_deleted' => false,
+        'expenditure_accounts_dimensions_id' => null,
+        'amortization_accounts_dimensions_id' => null,
+    ];
+}

--- a/src/Testing/Responses/Fixtures/AccountDimensions/ListResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/AccountDimensions/ListResponseFixture.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Testing\Responses\Fixtures\AccountDimensions;
+
+final class ListResponseFixture
+{
+    /**
+     * @var array<int, array<string, mixed>>
+     */
+    public const ATTRIBUTES = [
+        AccountDimensionResponseFixture::ATTRIBUTES,
+    ];
+}

--- a/src/Testing/Responses/Fixtures/Accounts/AccountResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/Accounts/AccountResponseFixture.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Testing\Responses\Fixtures\Accounts;
+
+/**
+ * OpenAPI `Accounts` schema example (fuller projection).
+ *
+ * @see https://rmp-api.rik.ee/openapi.yaml
+ */
+final class AccountResponseFixture
+{
+    /**
+     * @var array<string, mixed>
+     */
+    public const ATTRIBUTES = [
+        'id' => 1010,
+        'balance_type' => 'D',
+        'account_type_est' => 'Varad',
+        'account_type_eng' => 'Assets',
+        'name_est' => 'Sularaha kassas',
+        'name_eng' => 'Cash on hand',
+        'is_valid' => true,
+        'allows_deactivation' => false,
+        'is_vat_account' => false,
+        'is_fixed_asset' => false,
+        'expenditure_accounts_id' => null,
+        'amortization_accounts_id' => null,
+        'transaction_in_bindable' => true,
+        'transaction_out_bindable' => true,
+        'priority' => 1010,
+        'cl_account_groups' => [
+            'AR',
+            'MTY',
+            'SA',
+        ],
+        'default_disabled' => false,
+        'transaction_in_user_bindable' => false,
+        'transaction_out_user_bindable' => false,
+        'is_product_account' => false,
+        'allows_dimensions' => true,
+        'requires_client' => false,
+        'requires_positive_balance' => false,
+        'is_disabled' => false,
+        'transaction_in_user_bindable_set' => false,
+        'transaction_out_user_bindable_set' => false,
+    ];
+}

--- a/src/Testing/Responses/Fixtures/Accounts/ListResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/Accounts/ListResponseFixture.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Testing\Responses\Fixtures\Accounts;
+
+final class ListResponseFixture
+{
+    /**
+     * @var array<int, array<string, mixed>>
+     */
+    public const ATTRIBUTES = [
+        AccountResponseFixture::ATTRIBUTES,
+    ];
+}

--- a/src/Testing/Responses/Fixtures/ApiFileResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/ApiFileResponseFixture.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Testing\Responses\Fixtures;
+
+final class ApiFileResponseFixture
+{
+    /**
+     * @var array{name: string, contents: string}
+     */
+    public const ATTRIBUTES = [
+        'name' => 'Arve_NX000001_20220109_TESTCLIENT.pdf',
+        'contents' => 'JVBERi0xLjQK',
+    ];
+}

--- a/src/Testing/Responses/Fixtures/Bank/BankAccountResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/Bank/BankAccountResponseFixture.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Testing\Responses\Fixtures\Bank;
+
+/**
+ * OpenAPI `BankAccounts` schema example (fuller projection).
+ *
+ * @see https://rmp-api.rik.ee/openapi.yaml
+ */
+final class BankAccountResponseFixture
+{
+    /**
+     * @var array<string, mixed>
+     */
+    public const ATTRIBUTES = [
+        'id' => 16,
+        'account_name_est' => 'Swedbank AS EE123456780012345678',
+        'account_name_eng' => 'Swedbank AS EE123456780012345678',
+        'account_no' => 'EE123456780012345678',
+        'cl_banks_id' => 1,
+        'bank_name' => null,
+        'bank_regcode' => null,
+        'iban_code' => 'EE123456780012345678',
+        'swift_code' => 'HABAEE2X',
+        'start_sum' => null,
+        'day_limit' => null,
+        'credit_limit' => null,
+        'show_in_sale_invoices' => true,
+        'default_salary_account' => true,
+        'beneficiary_name' => null,
+        'accounts_dimensions_id' => 2,
+        'clients_id' => 56,
+    ];
+}

--- a/src/Testing/Responses/Fixtures/Bank/ListResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/Bank/ListResponseFixture.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Testing\Responses\Fixtures\Bank;
+
+final class ListResponseFixture
+{
+    /**
+     * @var array<int, array<string, mixed>>
+     */
+    public const ATTRIBUTES = [
+        BankAccountResponseFixture::ATTRIBUTES,
+    ];
+}

--- a/src/Testing/Responses/Fixtures/CostProfitCentres/CostProfitCentreResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/CostProfitCentres/CostProfitCentreResponseFixture.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Testing\Responses\Fixtures\CostProfitCentres;
+
+/**
+ * OpenAPI `Projects` schema example (fuller projection).
+ *
+ * @see https://rmp-api.rik.ee/openapi.yaml
+ */
+final class CostProfitCentreResponseFixture
+{
+    /**
+     * @var array<string, mixed>
+     */
+    public const ATTRIBUTES = [
+        'id' => 12,
+        'parent_id' => 11,
+        'name' => 'Elekter',
+        'notes' => null,
+        'cl_projects_type' => 'PROJECT',
+        'is_disabled' => false,
+        'create_date' => '2014-06-18',
+        'deprecated_parent_id' => 11,
+        'is_deleted' => false,
+    ];
+}

--- a/src/Testing/Responses/Fixtures/CostProfitCentres/ListResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/CostProfitCentres/ListResponseFixture.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Testing\Responses\Fixtures\CostProfitCentres;
+
+final class ListResponseFixture
+{
+    /**
+     * @var array{current_page: int, total_pages: int, items: array<int, array<string, mixed>>}
+     */
+    public const ATTRIBUTES = [
+        'current_page' => 1,
+        'total_pages' => 1,
+        'items' => [
+            CostProfitCentreResponseFixture::ATTRIBUTES,
+        ],
+    ];
+}

--- a/src/Testing/Responses/Fixtures/PurchaseArticles/ListResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/PurchaseArticles/ListResponseFixture.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Testing\Responses\Fixtures\PurchaseArticles;
+
+final class ListResponseFixture
+{
+    /**
+     * @var array<int, array<string, mixed>>
+     */
+    public const ATTRIBUTES = [
+        PurchaseArticleResponseFixture::ATTRIBUTES,
+    ];
+}

--- a/src/Testing/Responses/Fixtures/PurchaseArticles/PurchaseArticleResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/PurchaseArticles/PurchaseArticleResponseFixture.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Testing\Responses\Fixtures\PurchaseArticles;
+
+/**
+ * OpenAPI `PurchaseArticles` schema example (fuller projection).
+ *
+ * @see https://rmp-api.rik.ee/openapi.yaml
+ */
+final class PurchaseArticleResponseFixture
+{
+    /**
+     * @var array<string, mixed>
+     */
+    public const ATTRIBUTES = [
+        'id' => 89,
+        'level' => 2,
+        'name_est' => 'Sisendkäibemaks, tollis impordilt tasutud',
+        'name_eng' => 'Input VAT, customs paid on imports',
+        'accounts_id' => 1510,
+        'priority' => 15100,
+        'cl_account_groups' => [
+            'AR',
+            'MTY',
+            'SA',
+        ],
+        'is_disabled' => false,
+    ];
+}

--- a/src/Testing/Responses/Fixtures/SalesArticles/ListResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/SalesArticles/ListResponseFixture.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Testing\Responses\Fixtures\SalesArticles;
+
+final class ListResponseFixture
+{
+    /**
+     * @var array<int, array<string, mixed>>
+     */
+    public const ATTRIBUTES = [
+        SalesArticleResponseFixture::ATTRIBUTES,
+    ];
+}

--- a/src/Testing/Responses/Fixtures/SalesArticles/SalesArticleResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/SalesArticles/SalesArticleResponseFixture.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Testing\Responses\Fixtures\SalesArticles;
+
+/**
+ * OpenAPI `SaleArticles` schema example (fuller projection).
+ *
+ * @see https://rmp-api.rik.ee/openapi.yaml
+ */
+final class SalesArticleResponseFixture
+{
+    /**
+     * @var array<string, mixed>
+     */
+    public const ATTRIBUTES = [
+        'id' => 34,
+        'group_est' => 'Pandipakendid',
+        'group_eng' => 'Pledge packages',
+        'name_est' => 'Pandipakendid',
+        'name_eng' => 'Pledge packages',
+        'accounts_id' => 1615,
+        'vat_accounts_id' => null,
+        'vat_rate' => null,
+        'vat_type' => 0,
+        'is_valid' => true,
+        'start_date' => null,
+        'end_date' => null,
+        'priority' => 15,
+        'cl_account_groups' => [
+            'AR',
+            'MTY',
+            'SA',
+        ],
+        'description_est' => null,
+        'description_eng' => null,
+    ];
+}

--- a/tests/Client.php
+++ b/tests/Client.php
@@ -8,10 +8,18 @@ use EFinancialsClient\Resources\PurchaseInvoices;
 use EFinancialsClient\Resources\SalesInvoices;
 use EFinancialsClient\Resources\Templates;
 use EFinancialsClient\Resources\Transactions;
+use EFinancialsClient\Responses\Accounts\AccountResponse;
+use EFinancialsClient\Responses\Accounts\ListResponse as AccountsListResponse;
+use EFinancialsClient\Responses\ApiFileResponse;
+use EFinancialsClient\Responses\Bank\BankAccountResponse;
+use EFinancialsClient\Responses\Bank\ListResponse as BankAccountsListResponse;
 use EFinancialsClient\Responses\Clients\ClientResponse;
 use EFinancialsClient\Responses\Clients\ListResponse as ClientsListResponse;
+use EFinancialsClient\Responses\CostProfitCentres\ListResponse as CostProfitCentresListResponse;
 use EFinancialsClient\Responses\Currencies\ListResponse as CurrenciesListResponse;
 use EFinancialsClient\Testing\ClientFake;
+use EFinancialsClient\Testing\Responses\Fixtures\Accounts\AccountResponseFixture;
+use EFinancialsClient\Testing\Responses\Fixtures\Bank\BankAccountResponseFixture;
 use EFinancialsClient\Testing\Responses\Fixtures\Clients\ClientResponseFixture;
 use EFinancialsClient\Transporters\HttpTransporter;
 use EFinancialsClient\ValueObjects\ApiCredentials;
@@ -48,7 +56,7 @@ it('returns decoded json from a successful request', function () {
 
     $client = new Client($transporter);
 
-    expect($client->accounts()->all())->toBe(['ok' => true]);
+    expect($client->products()->all())->toBe(['ok' => true]);
 });
 
 it('throws a typed exception for http errors', function () {
@@ -62,7 +70,7 @@ it('throws a typed exception for http errors', function () {
     );
 
     $client = new Client($transporter);
-    $client->accounts()->all();
+    $client->products()->all();
 })->throws(ErrorException::class, 'Unauthorized');
 
 it('exposes resource accessors', function () {
@@ -127,6 +135,55 @@ it('maps clients to a fuller OpenAPI projection', function () {
 
     $fake->assertSent('clients', fn (Payload $payload): bool => $payload->method()->value === 'GET');
     $fake->assertSent('clients/1916', fn (Payload $payload): bool => $payload->method()->value === 'GET');
+});
+
+it('maps accounts and bank accounts to fuller OpenAPI projections', function () {
+    $fake = new ClientFake([
+        AccountsListResponse::fake(),
+        BankAccountsListResponse::fake(),
+        BankAccountResponse::fake(),
+        CostProfitCentresListResponse::fake(),
+        ApiFileResponse::fake(),
+    ]);
+
+    $accounts = $fake->accounts()->all();
+
+    expect($accounts)->toBeInstanceOf(AccountsListResponse::class)
+        ->and($accounts->data[0])->toBeInstanceOf(AccountResponse::class)
+        ->and($accounts->data[0]->id)->toBe(1010)
+        ->and($accounts->data[0]->nameEst)->toBe('Sularaha kassas')
+        ->and($accounts->data[0]->clAccountGroups)->toBe(['AR', 'MTY', 'SA'])
+        ->and($accounts->data[0]->toArray())->toBe(
+            AccountResponse::from(AccountResponseFixture::ATTRIBUTES)->toArray()
+        );
+
+    $bankAccounts = $fake->bank()->all();
+
+    expect($bankAccounts)->toBeInstanceOf(BankAccountsListResponse::class)
+        ->and($bankAccounts->data[0]->accountNo)->toBe('EE123456780012345678');
+
+    $bankAccount = $fake->bank()->get(16);
+
+    expect($bankAccount)->toBeInstanceOf(BankAccountResponse::class)
+        ->and($bankAccount->toArray())->toBe(
+            BankAccountResponse::from(BankAccountResponseFixture::ATTRIBUTES)->toArray()
+        );
+
+    $centres = $fake->costProfitCentres()->all();
+
+    expect($centres)->toBeInstanceOf(CostProfitCentresListResponse::class)
+        ->and($centres->items[0]->name)->toBe('Elekter')
+        ->and($centres->items[0]->clProjectsType)->toBe('PROJECT');
+
+    $file = ApiFileResponse::fake();
+
+    expect($file)->toBeInstanceOf(ApiFileResponse::class)
+        ->and($file->name)->toBe('Arve_NX000001_20220109_TESTCLIENT.pdf')
+        ->and($file->contents)->toBe('JVBERi0xLjQK');
+
+    $fake->assertSent('accounts', fn (Payload $payload): bool => $payload->method()->value === 'GET');
+    $fake->assertSent('bank_accounts', fn (Payload $payload): bool => $payload->method()->value === 'GET');
+    $fake->assertSent('projects', fn (Payload $payload): bool => $payload->method()->value === 'GET');
 });
 
 it('builds a client through the factory facade', function () {

--- a/tests/Integration/DemoApi.php
+++ b/tests/Integration/DemoApi.php
@@ -1,7 +1,13 @@
 <?php
 
+use EFinancialsClient\Responses\AccountDimensions\ListResponse as AccountDimensionsListResponse;
+use EFinancialsClient\Responses\Accounts\ListResponse as AccountsListResponse;
+use EFinancialsClient\Responses\Bank\ListResponse as BankAccountsListResponse;
 use EFinancialsClient\Responses\Clients\ListResponse as ClientsListResponse;
+use EFinancialsClient\Responses\CostProfitCentres\ListResponse as CostProfitCentresListResponse;
 use EFinancialsClient\Responses\Currencies\ListResponse as CurrenciesListResponse;
+use EFinancialsClient\Responses\PurchaseArticles\ListResponse as PurchaseArticlesListResponse;
+use EFinancialsClient\Responses\SalesArticles\ListResponse as SalesArticlesListResponse;
 use EFinancialsClient\Responses\Templates\ListResponse as TemplatesListResponse;
 use EFinancialsClient\Responses\VatInfo\VatInfoResponse;
 
@@ -35,13 +41,13 @@ it('validates demo api response shapes', function () {
     $vatInfo = $client->bank()->getVatInfo();
     expect($vatInfo)->toBeInstanceOf(VatInfoResponse::class);
 
-    expect($client->accounts()->all())->toBeArray()
-        ->and($client->accountDimensions()->all())->toBeArray()
-        ->and($client->bank()->all())->toBeArray()
+    expect($client->accounts()->all())->toBeInstanceOf(AccountsListResponse::class)
+        ->and($client->accountDimensions()->all())->toBeInstanceOf(AccountDimensionsListResponse::class)
+        ->and($client->bank()->all())->toBeInstanceOf(BankAccountsListResponse::class)
         ->and($client->products()->all())->toBeArray()
-        ->and($client->costProfitCentres()->all())->toBeArray()
-        ->and($client->salesArticles()->all())->toBeArray()
-        ->and($client->purchaseArticles()->all())->toBeArray()
+        ->and($client->costProfitCentres()->all())->toBeInstanceOf(CostProfitCentresListResponse::class)
+        ->and($client->salesArticles()->all())->toBeInstanceOf(SalesArticlesListResponse::class)
+        ->and($client->purchaseArticles()->all())->toBeInstanceOf(PurchaseArticlesListResponse::class)
         ->and($client->invoices()->all())->toBeArray()
         ->and($client->invoices()->allSettings())->toBeArray()
         ->and($client->journals()->all())->toBeArray()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

PR 2 from the post-#90 DTO plan: typed fuller OpenAPI projections for shared `ApiFile` and the flat classifier resources.

### Changes
1. **`ApiFileResponse`** — OpenAPI `ApiFile` (`name`, `contents`) + fixture (ready for document/XML/PDF endpoints).
2. **Flat classifiers** — entity + `ListResponse` (`data`) for:
   - Accounts (`Accounts`)
   - AccountDimensions (`AccountsDimensions`)
   - SalesArticles (`SaleArticles`)
   - PurchaseArticles (`PurchaseArticles`)
   - BankAccounts (`BankAccounts`) under `Responses/Bank`
3. **CostProfitCentres** — paginated `ListOfProjects` shape (`current_page` / `total_pages` / `items`).
4. **Bank mutations** — `create` / `update` / `delete` now return `ApiResponse` (aligned with Clients).
5. **Resources wired** to typed returns; HTTP decode unit tests moved off `accounts()` onto still-raw `products()`.
6. **`NormalizesAttributes::stringList()`** for `cl_account_groups` arrays.
7. **Fixtures** from OpenAPI examples; example-backed fields included when they are first-class (skipping denormalized `accounts__*` / `dimensions__*` join aliases).

### Out of scope
- Products (PR3)
- Per-resource contracts / ClientFake redesign / Payload helpers

### Verification
- `composer test` green (lint, PHPStan, type coverage, Pest)
- Demo API integration assertions updated for the new typed lists

### What
- [ ] Bug Fix
- [x] New Feature

### Description
Expand typed Response DTOs beyond Clients to ApiFile and flat OpenAPI classifier resources.

### Related
Follow-up to #91; grounded in https://rmp-api.rik.ee/openapi.yaml

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc292-2ac0-79d0-9014-6126f82761ad?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc292-2ac0-79d0-9014-6126f82761ad&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

