### PR TITLE
chore: add Cursor Cloud Agents environment

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -1,0 +1,30 @@
+# Cursor Cloud Agent base image for e-financials/php-client
+# PHP 8.4 matches CI / Pest 5 tooling (runtime requirement is ^8.2).
+FROM php:8.4-cli-bookworm
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        git \
+        sudo \
+        unzip \
+        curl \
+        ca-certificates \
+        libzip-dev \
+        libxml2-dev \
+        $PHPIZE_DEPS \
+    && docker-php-ext-install -j"$(nproc)" zip \
+    && pecl install pcov \
+    && docker-php-ext-enable pcov \
+    && apt-get purge -y --auto-remove $PHPIZE_DEPS \
+    && rm -rf /var/lib/apt/lists/*
+
+# Composer 2
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+# Non-root user with passwordless sudo (matches Cursor agent conventions)
+RUN useradd --create-home --shell /bin/bash ubuntu \
+    && echo 'ubuntu ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/ubuntu \
+    && chmod 0440 /etc/sudoers.d/ubuntu
+
+USER ubuntu
+WORKDIR /workspace

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,8 @@
+{
+  "name": "e-financials-php-client",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": "."
+  },
+  "install": "composer update --prefer-stable --no-interaction --prefer-dist"
+}

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,8 +1,7 @@
 {
   "name": "e-financials-php-client",
   "build": {
-    "dockerfile": "Dockerfile",
-    "context": "."
+    "dockerfile": "Dockerfile"
   },
   "install": "composer update --prefer-stable --no-interaction --prefer-dist"
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds a Cursor Cloud Agents environment so agents boot with PHP 8.4, Composer, and the same dependency install path as CI.

## Changes
- `.cursor/Dockerfile` — PHP 8.4 CLI image with `git`, `sudo`, `zip`, `pcov`, and Composer 2
- `.cursor/environment.json` — runs `composer update --prefer-stable --no-interaction --prefer-dist` on install (matches CI; no lockfile is committed)

## Verification
Draft environment builds from this branch succeeded:
- `bld-20260802-b9f6596c-40ef-46ef-ba43-44f94fbeaa95` — Docker image + `composer update` (Pest 5 / PHPStan / Pint)
- `bld-20260802-3cfa5f0d-000b-40bf-bc77-e2f10513b95d` — re-verified after dropping `build.context`

A personal transitional environment was linked for this setup run (`267ec61c-8e81-11f1-a7d1-d6b4613131ce`).

## Notes
- Library package: no long-running `start` process
- Dev tooling targets PHP 8.4+ (Pest 5); runtime requirement remains `^8.2`
- After merge, new cloud agents that start from a commit containing `.cursor/environment.json` will use this repo-file config
- Optional: in the [Cloud Agents dashboard](https://cursor.com/dashboard/cloud-agents#environments), save/promote a snapshot from `main` after merge for faster boots
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc2ef-48bb-7098-bd62-a48abd49d5f3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc2ef-48bb-7098-bd62-a48abd49d5f3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

