### PR TITLE
feat: expand Products response to full OpenAPI projection

### DIFF
--- a/src/Resources/Products.php
+++ b/src/Resources/Products.php
@@ -5,8 +5,14 @@ declare(strict_types=1);
 namespace EFinancialsClient\Resources;
 
 use DateTime;
+use DateTimeInterface;
 use EFinancialsClient\Resources\Concerns\Transportable;
+use EFinancialsClient\Responses\ApiResponse;
+use EFinancialsClient\Responses\Products\ListResponse;
+use EFinancialsClient\Responses\Products\ProductResponse;
 use EFinancialsClient\ValueObjects\Transporter\Payload;
+use EFinancialsClient\ValueObjects\Transporter\Response;
+use InvalidArgumentException;
 
 final class Products
 {
@@ -20,7 +26,7 @@ final class Products
      * @param  int  $page  Page of responses to return.
      * @param  DateTime|string  $modifiedSince  Return only objects modified since provided timestamp.
      */
-    public function all(int $page = 1, DateTime|string $modifiedSince = ''): mixed
+    public function all(int $page = 1, DateTime|string $modifiedSince = ''): ListResponse
     {
         $query = [];
 
@@ -29,17 +35,17 @@ final class Products
         }
 
         if ($modifiedSince !== '') {
-            // If $modifiedSince is a DateTime object, format it as an Atom string
-            // Otherwise, assign keep it as date string.
             $query['modified_since'] = ($modifiedSince instanceof DateTime)
-                ? $modifiedSince->format(\DateTimeInterface::ATOM)
+                ? $modifiedSince->format(DateTimeInterface::ATOM)
                 : $modifiedSince;
         }
 
         $payload = Payload::get('products', $query);
+
+        /** @var Response<array{current_page: int, total_pages: int, items: array<int, array<string, mixed>>}> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return ListResponse::from($response->data());
     }
 
     /**
@@ -49,12 +55,14 @@ final class Products
      *
      * @param  int  $id  Product identificator.
      */
-    public function get(int $id): mixed
+    public function get(int $id): ProductResponse
     {
         $payload = Payload::get('products/'.$id);
+
+        /** @var Response<array<string, mixed>> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return ProductResponse::from($response->data());
     }
 
     /**
@@ -62,41 +70,19 @@ final class Products
      *
      * @see https://rmp-api.rik.ee/api.html#operation/post-products
      *
-     * @param array<string,mixed>|array{
-     *   "activity_text": string,
-     *   "amount": string,
-     *   "cl_purchase_articles_id": null,
-     *   "cl_sale_articles_id": 1,
-     *   "description": null,
-     *   "emtak_code": null,
-     *   "emtak_version": null,
-     *   "foreign_names": array,
-     *   "id": int,
-     *   "is_deleted": false,
-     *   "net_price": null,
-     *   "notes": null,
-     *   "price_currency": "EUR",
-     *   "purchase_accounts_dimensions_id": null,
-     *   "purchase_accounts_id": null,
-     *   "sale_accounts_dimensions_id": null,
-     *   "sale_accounts_id": int,
-     *   "sales_price": int,
-     *   "translations": array,
-     *   "unit": "tk",
-     * } $parameters
+     * @param  array<string, mixed>  $parameters
      */
-    public function create(string $name, string $code, array $parameters = []): mixed
+    public function create(string $name, string $code, array $parameters = []): ApiResponse
     {
-
-        $required_parameters = [
+        $payload = Payload::post('products', array_merge([
             'name' => $name,
             'code' => $code,
-        ];
+        ], $parameters));
 
-        $payload = Payload::post('products', \array_merge($required_parameters, $parameters));
+        /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return ApiResponse::from($response->data());
     }
 
     /**
@@ -105,32 +91,10 @@ final class Products
      * @see https://rmp-api.rik.ee/api.html#operation/patch-products_one
      *
      * @param  int  $id  Product identificator.
-     * @param array<string,mixed>|array{
-     *   "activity_text": string,
-     *   "amount": string,
-     *   "cl_purchase_articles_id": null,
-     *   "cl_sale_articles_id": 1,
-     *   "description": null,
-     *   "emtak_code": null,
-     *   "emtak_version": null,
-     *   "foreign_names": array,
-     *   "id": int,
-     *   "is_deleted": false,
-     *   "net_price": null,
-     *   "notes": null,
-     *   "price_currency": "EUR",
-     *   "purchase_accounts_dimensions_id": null,
-     *   "purchase_accounts_id": null,
-     *   "sale_accounts_dimensions_id": null,
-     *   "sale_accounts_id": int,
-     *   "sales_price": int,
-     *   "translations": array,
-     *   "unit": "tk",
-     * } $parameters
+     * @param  array<string, mixed>  $parameters
      */
-    public function update(int $id, array $parameters = []): mixed
+    public function update(int $id, array $parameters = []): ApiResponse
     {
-
         $missingRequiredParameters = array_diff_key(
             array_flip(
                 [
@@ -144,15 +108,17 @@ final class Products
         if (count($missingRequiredParameters) !== 0) {
             $missingKeys = implode(', ', array_keys($missingRequiredParameters));
 
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 "Missing required parameter(s): $missingKeys"
             );
         }
 
         $payload = Payload::patch('products/'.$id, $parameters);
+
+        /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return ApiResponse::from($response->data());
     }
 
     /**
@@ -162,12 +128,14 @@ final class Products
      *
      * @param  int  $id  Product identificator.
      */
-    public function delete(int $id): mixed
+    public function delete(int $id): ApiResponse
     {
         $payload = Payload::delete('products/'.$id);
+
+        /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return ApiResponse::from($response->data());
     }
 
     /**
@@ -177,12 +145,14 @@ final class Products
      *
      * @param  int  $id  Product identificator.
      */
-    public function deactivate(int $id): mixed
+    public function deactivate(int $id): ApiResponse
     {
         $payload = Payload::patch('products/'.$id.'/deactivate');
+
+        /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return ApiResponse::from($response->data());
     }
 
     /**
@@ -192,11 +162,13 @@ final class Products
      *
      * @param  int  $id  Product identificator.
      */
-    public function reactivate(int $id): mixed
+    public function reactivate(int $id): ApiResponse
     {
         $payload = Payload::patch('products/'.$id.'/reactivate');
+
+        /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return ApiResponse::from($response->data());
     }
 }

--- a/src/Responses/Concerns/NormalizesAttributes.php
+++ b/src/Responses/Concerns/NormalizesAttributes.php
@@ -115,4 +115,32 @@ trait NormalizesAttributes
 
         return $list;
     }
+
+    /**
+     * @return array<string, string>
+     */
+    private static function stringMap(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        $map = [];
+
+        foreach ($value as $key => $item) {
+            $mapKey = is_string($key) ? $key : (string) $key;
+
+            if ($item === null) {
+                $map[$mapKey] = '';
+
+                continue;
+            }
+
+            if (is_string($item) || is_int($item) || is_float($item)) {
+                $map[$mapKey] = (string) $item;
+            }
+        }
+
+        return $map;
+    }
 }

--- a/src/Responses/Products/ListResponse.php
+++ b/src/Responses/Products/ListResponse.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Responses\Products;
+
+use EFinancialsClient\Contracts\ResponseContract;
+use EFinancialsClient\Responses\Concerns\ArrayAccessible;
+use EFinancialsClient\Responses\Concerns\NormalizesAttributes;
+use EFinancialsClient\Testing\Responses\Concerns\Fakeable;
+
+/**
+ * @phpstan-import-type ProductData from ProductResponse
+ *
+ * @implements ResponseContract<array{current_page: int, total_pages: int, items: array<int, ProductData>}>
+ */
+final class ListResponse implements ResponseContract
+{
+    /**
+     * @use ArrayAccessible<array{current_page: int, total_pages: int, items: array<int, ProductData>}>
+     */
+    use ArrayAccessible;
+
+    use Fakeable;
+    use NormalizesAttributes;
+
+    /**
+     * @param  array<int, ProductResponse>  $items
+     */
+    private function __construct(
+        public readonly int $currentPage,
+        public readonly int $totalPages,
+        public readonly array $items,
+    ) {}
+
+    /**
+     * @param  array<array-key, mixed>  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        /** @var array<int, array<string, mixed>> $rawItems */
+        $rawItems = is_array($attributes['items'] ?? null) ? $attributes['items'] : [];
+
+        $items = array_map(
+            static fn (array $item): ProductResponse => ProductResponse::from($item),
+            $rawItems,
+        );
+
+        return new self(
+            self::intValue($attributes['current_page'] ?? 0),
+            self::intValue($attributes['total_pages'] ?? 0),
+            $items,
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toArray(): array
+    {
+        return [
+            'current_page' => $this->currentPage,
+            'total_pages' => $this->totalPages,
+            'items' => array_map(
+                static fn (ProductResponse $product): array => $product->toArray(),
+                $this->items,
+            ),
+        ];
+    }
+}

--- a/src/Responses/Products/ProductResponse.php
+++ b/src/Responses/Products/ProductResponse.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Responses\Products;
+
+use EFinancialsClient\Contracts\ResponseContract;
+use EFinancialsClient\Responses\Concerns\ArrayAccessible;
+use EFinancialsClient\Responses\Concerns\NormalizesAttributes;
+use EFinancialsClient\Testing\Responses\Concerns\Fakeable;
+
+/**
+ * Full projection of the OpenAPI `Products` schema, plus example-backed `is_deleted`.
+ *
+ * @see https://rmp-api.rik.ee/api.html#operation/get-products_one
+ *
+ * @phpstan-type ProductData array{
+ *     id: int|null,
+ *     name: string,
+ *     foreign_names: array<string, string>,
+ *     cl_sale_articles_id: int|null,
+ *     sale_accounts_id: int|null,
+ *     sale_accounts_dimensions_id: int|null,
+ *     cl_purchase_articles_id: int|null,
+ *     purchase_accounts_id: int|null,
+ *     purchase_accounts_dimensions_id: int|null,
+ *     code: string,
+ *     description: string|null,
+ *     sales_price: float|null,
+ *     net_price: float|null,
+ *     price_currency: string|null,
+ *     notes: string|null,
+ *     translations: array<string, string>,
+ *     activity_text: string|null,
+ *     emtak_code: string|null,
+ *     emtak_version: string|null,
+ *     unit: string|null,
+ *     amount: float|null,
+ *     is_deleted: bool|null
+ * }
+ *
+ * @implements ResponseContract<ProductData>
+ */
+final class ProductResponse implements ResponseContract
+{
+    /**
+     * @use ArrayAccessible<ProductData>
+     */
+    use ArrayAccessible;
+
+    use Fakeable;
+    use NormalizesAttributes;
+
+    /**
+     * @param  array<string, string>  $foreignNames
+     * @param  array<string, string>  $translations
+     */
+    private function __construct(
+        public readonly ?int $id,
+        public readonly string $name,
+        public readonly array $foreignNames,
+        public readonly ?int $clSaleArticlesId,
+        public readonly ?int $saleAccountsId,
+        public readonly ?int $saleAccountsDimensionsId,
+        public readonly ?int $clPurchaseArticlesId,
+        public readonly ?int $purchaseAccountsId,
+        public readonly ?int $purchaseAccountsDimensionsId,
+        public readonly string $code,
+        public readonly ?string $description,
+        public readonly ?float $salesPrice,
+        public readonly ?float $netPrice,
+        public readonly ?string $priceCurrency,
+        public readonly ?string $notes,
+        public readonly array $translations,
+        public readonly ?string $activityText,
+        public readonly ?string $emtakCode,
+        public readonly ?string $emtakVersion,
+        public readonly ?string $unit,
+        public readonly ?float $amount,
+        public readonly ?bool $isDeleted,
+    ) {}
+
+    /**
+     * @param  array<array-key, mixed>  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            self::intOrNull($attributes['id'] ?? null),
+            self::stringValue($attributes['name'] ?? null),
+            self::stringMap($attributes['foreign_names'] ?? null),
+            self::intOrNull($attributes['cl_sale_articles_id'] ?? null),
+            self::intOrNull($attributes['sale_accounts_id'] ?? null),
+            self::intOrNull($attributes['sale_accounts_dimensions_id'] ?? null),
+            self::intOrNull($attributes['cl_purchase_articles_id'] ?? null),
+            self::intOrNull($attributes['purchase_accounts_id'] ?? null),
+            self::intOrNull($attributes['purchase_accounts_dimensions_id'] ?? null),
+            self::stringValue($attributes['code'] ?? null),
+            self::stringOrNull($attributes['description'] ?? null),
+            self::floatOrNull($attributes['sales_price'] ?? null),
+            self::floatOrNull($attributes['net_price'] ?? null),
+            self::stringOrNull($attributes['price_currency'] ?? null),
+            self::stringOrNull($attributes['notes'] ?? null),
+            self::stringMap($attributes['translations'] ?? null),
+            self::stringOrNull($attributes['activity_text'] ?? null),
+            self::stringOrNull($attributes['emtak_code'] ?? null),
+            self::stringOrNull($attributes['emtak_version'] ?? null),
+            self::stringOrNull($attributes['unit'] ?? null),
+            self::floatOrNull($attributes['amount'] ?? null),
+            self::boolOrNull($attributes['is_deleted'] ?? null),
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'foreign_names' => $this->foreignNames,
+            'cl_sale_articles_id' => $this->clSaleArticlesId,
+            'sale_accounts_id' => $this->saleAccountsId,
+            'sale_accounts_dimensions_id' => $this->saleAccountsDimensionsId,
+            'cl_purchase_articles_id' => $this->clPurchaseArticlesId,
+            'purchase_accounts_id' => $this->purchaseAccountsId,
+            'purchase_accounts_dimensions_id' => $this->purchaseAccountsDimensionsId,
+            'code' => $this->code,
+            'description' => $this->description,
+            'sales_price' => $this->salesPrice,
+            'net_price' => $this->netPrice,
+            'price_currency' => $this->priceCurrency,
+            'notes' => $this->notes,
+            'translations' => $this->translations,
+            'activity_text' => $this->activityText,
+            'emtak_code' => $this->emtakCode,
+            'emtak_version' => $this->emtakVersion,
+            'unit' => $this->unit,
+            'amount' => $this->amount,
+            'is_deleted' => $this->isDeleted,
+        ];
+    }
+}

--- a/src/Testing/Responses/Fixtures/Products/ListResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/Products/ListResponseFixture.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Testing\Responses\Fixtures\Products;
+
+final class ListResponseFixture
+{
+    /**
+     * @var array{current_page: int, total_pages: int, items: array<int, array<string, mixed>>}
+     */
+    public const ATTRIBUTES = [
+        'current_page' => 1,
+        'total_pages' => 1,
+        'items' => [
+            ProductResponseFixture::ATTRIBUTES,
+        ],
+    ];
+}

--- a/src/Testing/Responses/Fixtures/Products/ProductResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/Products/ProductResponseFixture.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Testing\Responses\Fixtures\Products;
+
+/**
+ * OpenAPI `Products` schema example (fuller projection).
+ *
+ * @see https://rmp-api.rik.ee/openapi.yaml
+ */
+final class ProductResponseFixture
+{
+    /**
+     * @var array<string, mixed>
+     */
+    public const ATTRIBUTES = [
+        'id' => 36166,
+        'name' => 'printer HP',
+        'foreign_names' => [],
+        'cl_sale_articles_id' => 1,
+        'sale_accounts_id' => 3100,
+        'sale_accounts_dimensions_id' => null,
+        'cl_purchase_articles_id' => null,
+        'purchase_accounts_id' => null,
+        'purchase_accounts_dimensions_id' => null,
+        'code' => 'HP',
+        'description' => null,
+        'sales_price' => 170.0,
+        'net_price' => null,
+        'price_currency' => 'EUR',
+        'notes' => null,
+        'translations' => [
+            'products__name__1' => '',
+        ],
+        'activity_text' => null,
+        'emtak_code' => null,
+        'emtak_version' => null,
+        'unit' => 'tk',
+        'amount' => null,
+        'is_deleted' => false,
+    ];
+}

--- a/tests/Client.php
+++ b/tests/Client.php
@@ -17,10 +17,13 @@ use EFinancialsClient\Responses\Clients\ClientResponse;
 use EFinancialsClient\Responses\Clients\ListResponse as ClientsListResponse;
 use EFinancialsClient\Responses\CostProfitCentres\ListResponse as CostProfitCentresListResponse;
 use EFinancialsClient\Responses\Currencies\ListResponse as CurrenciesListResponse;
+use EFinancialsClient\Responses\Products\ListResponse as ProductsListResponse;
+use EFinancialsClient\Responses\Products\ProductResponse;
 use EFinancialsClient\Testing\ClientFake;
 use EFinancialsClient\Testing\Responses\Fixtures\Accounts\AccountResponseFixture;
 use EFinancialsClient\Testing\Responses\Fixtures\Bank\BankAccountResponseFixture;
 use EFinancialsClient\Testing\Responses\Fixtures\Clients\ClientResponseFixture;
+use EFinancialsClient\Testing\Responses\Fixtures\Products\ProductResponseFixture;
 use EFinancialsClient\Transporters\HttpTransporter;
 use EFinancialsClient\ValueObjects\ApiCredentials;
 use EFinancialsClient\ValueObjects\Transporter\BaseUri;
@@ -56,7 +59,7 @@ it('returns decoded json from a successful request', function () {
 
     $client = new Client($transporter);
 
-    expect($client->products()->all())->toBe(['ok' => true]);
+    expect($client->journals()->all())->toBe(['ok' => true]);
 });
 
 it('throws a typed exception for http errors', function () {
@@ -70,7 +73,7 @@ it('throws a typed exception for http errors', function () {
     );
 
     $client = new Client($transporter);
-    $client->products()->all();
+    $client->journals()->all();
 })->throws(ErrorException::class, 'Unauthorized');
 
 it('exposes resource accessors', function () {
@@ -184,6 +187,37 @@ it('maps accounts and bank accounts to fuller OpenAPI projections', function () 
     $fake->assertSent('accounts', fn (Payload $payload): bool => $payload->method()->value === 'GET');
     $fake->assertSent('bank_accounts', fn (Payload $payload): bool => $payload->method()->value === 'GET');
     $fake->assertSent('projects', fn (Payload $payload): bool => $payload->method()->value === 'GET');
+});
+
+it('maps products to a fuller OpenAPI projection', function () {
+    $fake = new ClientFake([
+        ProductsListResponse::fake(),
+        ProductResponse::fake(),
+    ]);
+
+    $list = $fake->products()->all();
+
+    expect($list)->toBeInstanceOf(ProductsListResponse::class)
+        ->and($list->items)->toHaveCount(1)
+        ->and($list->items[0])->toBeInstanceOf(ProductResponse::class)
+        ->and($list->items[0]->id)->toBe(36166)
+        ->and($list->items[0]->name)->toBe('printer HP')
+        ->and($list->items[0]->code)->toBe('HP')
+        ->and($list->items[0]->salesPrice)->toBe(170.0)
+        ->and($list->items[0]->translations)->toBe(['products__name__1' => ''])
+        ->and($list->items[0]->isDeleted)->toBeFalse()
+        ->and($list->items[0]->toArray())->toBe(
+            ProductResponse::from(ProductResponseFixture::ATTRIBUTES)->toArray()
+        );
+
+    $product = $fake->products()->get(36166);
+
+    expect($product)->toBeInstanceOf(ProductResponse::class)
+        ->and($product->priceCurrency)->toBe('EUR')
+        ->and($product->unit)->toBe('tk');
+
+    $fake->assertSent('products', fn (Payload $payload): bool => $payload->method()->value === 'GET');
+    $fake->assertSent('products/36166', fn (Payload $payload): bool => $payload->method()->value === 'GET');
 });
 
 it('builds a client through the factory facade', function () {

--- a/tests/Integration/DemoApi.php
+++ b/tests/Integration/DemoApi.php
@@ -6,6 +6,7 @@ use EFinancialsClient\Responses\Bank\ListResponse as BankAccountsListResponse;
 use EFinancialsClient\Responses\Clients\ListResponse as ClientsListResponse;
 use EFinancialsClient\Responses\CostProfitCentres\ListResponse as CostProfitCentresListResponse;
 use EFinancialsClient\Responses\Currencies\ListResponse as CurrenciesListResponse;
+use EFinancialsClient\Responses\Products\ListResponse as ProductsListResponse;
 use EFinancialsClient\Responses\PurchaseArticles\ListResponse as PurchaseArticlesListResponse;
 use EFinancialsClient\Responses\SalesArticles\ListResponse as SalesArticlesListResponse;
 use EFinancialsClient\Responses\Templates\ListResponse as TemplatesListResponse;
@@ -44,7 +45,7 @@ it('validates demo api response shapes', function () {
     expect($client->accounts()->all())->toBeInstanceOf(AccountsListResponse::class)
         ->and($client->accountDimensions()->all())->toBeInstanceOf(AccountDimensionsListResponse::class)
         ->and($client->bank()->all())->toBeInstanceOf(BankAccountsListResponse::class)
-        ->and($client->products()->all())->toBeArray()
+        ->and($client->products()->all())->toBeInstanceOf(ProductsListResponse::class)
         ->and($client->costProfitCentres()->all())->toBeInstanceOf(CostProfitCentresListResponse::class)
         ->and($client->salesArticles()->all())->toBeInstanceOf(SalesArticlesListResponse::class)
         ->and($client->purchaseArticles()->all())->toBeInstanceOf(PurchaseArticlesListResponse::class)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

PR 3 from the post-#90 DTO plan: typed fuller OpenAPI projection for Products (Clients twin: list/get + mutations).

### Changes
1. **`ProductResponse`** — all 21 `Products` schema properties from [`openapi.yaml`](https://rmp-api.rik.ee/openapi.yaml), plus example-backed `is_deleted`.
2. **`Products\ListResponse`** — paginated `ListOfProducts` shape (`current_page` / `total_pages` / `items`).
3. **Maps** — `foreign_names` / `translations` as `array<string, string>` via new `NormalizesAttributes::stringMap()` (preserves empty string values).
4. **`Products` resource** — `all`/`get` return typed DTOs; `create`/`update`/`delete`/`deactivate`/`reactivate` return `ApiResponse`.
5. **Tests** — `ClientFake` mapping coverage; demo API asserts `ProductsListResponse`; HTTP decode unit tests moved to still-raw `journals()`.

### Out of scope
- Invoices series/info (PR6)
- Journals / Transactions / invoice families
- Per-resource contracts / ClientFake redesign / Payload helpers

### Verification
- `composer test` green (lint, PHPStan, type coverage, Pest)
- Demo API integration green against live credentials

### What
- [ ] Bug Fix
- [x] New Feature

### Description
Expand Products typed responses to the full OpenAPI projection.

### Related
Follow-up to #91 / #93; grounded in https://rmp-api.rik.ee/openapi.yaml

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc292-2ac0-79d0-9014-6126f82761ad?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc292-2ac0-79d0-9014-6126f82761ad&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

