### PR TITLE
feat: add per-resource Contracts/Resources interfaces

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -5,6 +5,21 @@ declare(strict_types=1);
 namespace EFinancialsClient;
 
 use EFinancialsClient\Contracts\ClientContract;
+use EFinancialsClient\Contracts\Resources\AccountDimensionsContract;
+use EFinancialsClient\Contracts\Resources\AccountsContract;
+use EFinancialsClient\Contracts\Resources\BankContract;
+use EFinancialsClient\Contracts\Resources\ClientsContract;
+use EFinancialsClient\Contracts\Resources\CostProfitCentresContract;
+use EFinancialsClient\Contracts\Resources\CurrenciesContract;
+use EFinancialsClient\Contracts\Resources\InvoicesContract;
+use EFinancialsClient\Contracts\Resources\JournalsContract;
+use EFinancialsClient\Contracts\Resources\ProductsContract;
+use EFinancialsClient\Contracts\Resources\PurchaseArticlesContract;
+use EFinancialsClient\Contracts\Resources\PurchaseInvoicesContract;
+use EFinancialsClient\Contracts\Resources\SalesArticlesContract;
+use EFinancialsClient\Contracts\Resources\SalesInvoicesContract;
+use EFinancialsClient\Contracts\Resources\TemplatesContract;
+use EFinancialsClient\Contracts\Resources\TransactionsContract;
 use EFinancialsClient\Contracts\TransporterContract;
 use EFinancialsClient\Resources\AccountDimensions;
 use EFinancialsClient\Resources\Accounts;
@@ -29,77 +44,77 @@ final class Client implements ClientContract
         // ..
     }
 
-    public function accountDimensions(): AccountDimensions
+    public function accountDimensions(): AccountDimensionsContract
     {
         return new AccountDimensions($this->transporter);
     }
 
-    public function accounts(): Accounts
+    public function accounts(): AccountsContract
     {
         return new Accounts($this->transporter);
     }
 
-    public function bank(): Bank
+    public function bank(): BankContract
     {
         return new Bank($this->transporter);
     }
 
-    public function clients(): Clients
+    public function clients(): ClientsContract
     {
         return new Clients($this->transporter);
     }
 
-    public function costProfitCentres(): CostProfitCentres
+    public function costProfitCentres(): CostProfitCentresContract
     {
         return new CostProfitCentres($this->transporter);
     }
 
-    public function currencies(): Currencies
+    public function currencies(): CurrenciesContract
     {
         return new Currencies($this->transporter);
     }
 
-    public function invoices(): Invoices
+    public function invoices(): InvoicesContract
     {
         return new Invoices($this->transporter);
     }
 
-    public function journals(): Journals
+    public function journals(): JournalsContract
     {
         return new Journals($this->transporter);
     }
 
-    public function products(): Products
+    public function products(): ProductsContract
     {
         return new Products($this->transporter);
     }
 
-    public function purchaseArticles(): PurchaseArticles
+    public function purchaseArticles(): PurchaseArticlesContract
     {
         return new PurchaseArticles($this->transporter);
     }
 
-    public function purchaseInvoices(): PurchaseInvoices
+    public function purchaseInvoices(): PurchaseInvoicesContract
     {
         return new PurchaseInvoices($this->transporter);
     }
 
-    public function salesArticles(): SalesArticles
+    public function salesArticles(): SalesArticlesContract
     {
         return new SalesArticles($this->transporter);
     }
 
-    public function salesInvoices(): SalesInvoices
+    public function salesInvoices(): SalesInvoicesContract
     {
         return new SalesInvoices($this->transporter);
     }
 
-    public function templates(): Templates
+    public function templates(): TemplatesContract
     {
         return new Templates($this->transporter);
     }
 
-    public function transactions(): Transactions
+    public function transactions(): TransactionsContract
     {
         return new Transactions($this->transporter);
     }

--- a/src/Contracts/ClientContract.php
+++ b/src/Contracts/ClientContract.php
@@ -4,51 +4,51 @@ declare(strict_types=1);
 
 namespace EFinancialsClient\Contracts;
 
-use EFinancialsClient\Resources\AccountDimensions;
-use EFinancialsClient\Resources\Accounts;
-use EFinancialsClient\Resources\Bank;
-use EFinancialsClient\Resources\Clients;
-use EFinancialsClient\Resources\CostProfitCentres;
-use EFinancialsClient\Resources\Currencies;
-use EFinancialsClient\Resources\Invoices;
-use EFinancialsClient\Resources\Journals;
-use EFinancialsClient\Resources\Products;
-use EFinancialsClient\Resources\PurchaseArticles;
-use EFinancialsClient\Resources\PurchaseInvoices;
-use EFinancialsClient\Resources\SalesArticles;
-use EFinancialsClient\Resources\SalesInvoices;
-use EFinancialsClient\Resources\Templates;
-use EFinancialsClient\Resources\Transactions;
+use EFinancialsClient\Contracts\Resources\AccountDimensionsContract;
+use EFinancialsClient\Contracts\Resources\AccountsContract;
+use EFinancialsClient\Contracts\Resources\BankContract;
+use EFinancialsClient\Contracts\Resources\ClientsContract;
+use EFinancialsClient\Contracts\Resources\CostProfitCentresContract;
+use EFinancialsClient\Contracts\Resources\CurrenciesContract;
+use EFinancialsClient\Contracts\Resources\InvoicesContract;
+use EFinancialsClient\Contracts\Resources\JournalsContract;
+use EFinancialsClient\Contracts\Resources\ProductsContract;
+use EFinancialsClient\Contracts\Resources\PurchaseArticlesContract;
+use EFinancialsClient\Contracts\Resources\PurchaseInvoicesContract;
+use EFinancialsClient\Contracts\Resources\SalesArticlesContract;
+use EFinancialsClient\Contracts\Resources\SalesInvoicesContract;
+use EFinancialsClient\Contracts\Resources\TemplatesContract;
+use EFinancialsClient\Contracts\Resources\TransactionsContract;
 
 interface ClientContract
 {
-    public function accountDimensions(): AccountDimensions;
+    public function accountDimensions(): AccountDimensionsContract;
 
-    public function accounts(): Accounts;
+    public function accounts(): AccountsContract;
 
-    public function bank(): Bank;
+    public function bank(): BankContract;
 
-    public function clients(): Clients;
+    public function clients(): ClientsContract;
 
-    public function costProfitCentres(): CostProfitCentres;
+    public function costProfitCentres(): CostProfitCentresContract;
 
-    public function currencies(): Currencies;
+    public function currencies(): CurrenciesContract;
 
-    public function invoices(): Invoices;
+    public function invoices(): InvoicesContract;
 
-    public function journals(): Journals;
+    public function journals(): JournalsContract;
 
-    public function products(): Products;
+    public function products(): ProductsContract;
 
-    public function purchaseArticles(): PurchaseArticles;
+    public function purchaseArticles(): PurchaseArticlesContract;
 
-    public function purchaseInvoices(): PurchaseInvoices;
+    public function purchaseInvoices(): PurchaseInvoicesContract;
 
-    public function salesArticles(): SalesArticles;
+    public function salesArticles(): SalesArticlesContract;
 
-    public function salesInvoices(): SalesInvoices;
+    public function salesInvoices(): SalesInvoicesContract;
 
-    public function templates(): Templates;
+    public function templates(): TemplatesContract;
 
-    public function transactions(): Transactions;
+    public function transactions(): TransactionsContract;
 }

--- a/src/Contracts/Resources/AccountDimensionsContract.php
+++ b/src/Contracts/Resources/AccountDimensionsContract.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Contracts\Resources;
+
+use EFinancialsClient\Responses\AccountDimensions\ListResponse;
+
+interface AccountDimensionsContract
+{
+    /**
+     * Retrieve the account dimensions (subaccounts) of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/get-account_dimensions
+     */
+    public function all(): ListResponse;
+}

--- a/src/Contracts/Resources/AccountsContract.php
+++ b/src/Contracts/Resources/AccountsContract.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Contracts\Resources;
+
+use EFinancialsClient\Responses\Accounts\ListResponse;
+
+interface AccountsContract
+{
+    /**
+     * Retrieve the account structure of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/get-accounts
+     */
+    public function all(): ListResponse;
+}

--- a/src/Contracts/Resources/BankContract.php
+++ b/src/Contracts/Resources/BankContract.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Contracts\Resources;
+
+use EFinancialsClient\Responses\ApiResponse;
+use EFinancialsClient\Responses\Bank\BankAccountResponse;
+use EFinancialsClient\Responses\Bank\ListResponse;
+use EFinancialsClient\Responses\VatInfo\VatInfoResponse;
+
+interface BankContract
+{
+    /**
+     * Retrieve the bank account list of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/get-bank_accounts
+     */
+    public function all(): ListResponse;
+
+    /**
+     * Retrieve one specific bank account of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/get-bank_accounts_one
+     */
+    public function get(int $id): BankAccountResponse;
+
+    /**
+     * Create a new bank account of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/post-bank_accounts
+     *
+     * @param  array<string, mixed>  $parameters
+     */
+    public function create(array $parameters = []): ApiResponse;
+
+    /**
+     * Modify one specific bank account of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/patch-bank_accounts_one
+     *
+     * @param  array<string, mixed>  $parameters
+     */
+    public function update(int $id, array $parameters): ApiResponse;
+
+    /**
+     * Delete one specific bank account of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/delete-bank_accounts_one
+     *
+     * @param  int  $id  Bank account identificator.
+     */
+    public function delete(int $id): ApiResponse;
+
+    /**
+     * Retrieve the VAT information of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/get-vat_info
+     */
+    public function getVatInfo(): VatInfoResponse;
+}

--- a/src/Contracts/Resources/ClientsContract.php
+++ b/src/Contracts/Resources/ClientsContract.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Contracts\Resources;
+
+use DateTime;
+use EFinancialsClient\Responses\ApiResponse;
+use EFinancialsClient\Responses\Clients\ClientResponse;
+use EFinancialsClient\Responses\Clients\ListResponse;
+
+interface ClientsContract
+{
+    /**
+     * Get all the clients.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/get-clients
+     *
+     * @param  int  $page  Page of responses to return.
+     * @param  DateTime|string  $modifiedSince  Return only objects modified since provided timestamp.
+     */
+    public function all(int $page = 1, DateTime|string $modifiedSince = ''): ListResponse;
+
+    /**
+     * Get a client.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/get-clients_one
+     *
+     * @param  int  $id  Client identificator.
+     */
+    public function get(int $id): ClientResponse;
+
+    /**
+     * Create a new client of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/post-clients
+     *
+     * @param  array<string, mixed>  $parameters  all request parameters.
+     */
+    public function create(array $parameters = []): ApiResponse;
+
+    /**
+     * Modify one specific client.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/patch-clients_one
+     *
+     * @param  array<string, mixed>  $parameters  all request parameters.
+     */
+    public function update(int $id, array $parameters): ApiResponse;
+
+    /**
+     * Delete one specific Client.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/delete-clients_one
+     *
+     * @param  int  $id  Client identificator.
+     */
+    public function delete(int $id): ApiResponse;
+
+    /**
+     * Deactivate one specific client.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/patch-clients_one_deactivate
+     *
+     * @param  int  $id  Client identificator.
+     */
+    public function deactivate(int $id): ApiResponse;
+
+    /**
+     * Reactivate one specific client.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/patch-clients_one_reactivate
+     *
+     * @param  int  $id  Client identificator.
+     */
+    public function reactivate(int $id): ApiResponse;
+}

--- a/src/Contracts/Resources/CostProfitCentresContract.php
+++ b/src/Contracts/Resources/CostProfitCentresContract.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Contracts\Resources;
+
+use DateTime;
+use EFinancialsClient\Responses\CostProfitCentres\ListResponse;
+
+interface CostProfitCentresContract
+{
+    /**
+     * Retrieve the cost/profit centres list of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/get-projects
+     *
+     * @param  int  $page  Page of responses to return.
+     * @param  DateTime|string  $modifiedSince  Return only objects modified since provided timestamp.
+     */
+    public function all(int $page = 1, DateTime|string $modifiedSince = ''): ListResponse;
+}

--- a/src/Contracts/Resources/CurrenciesContract.php
+++ b/src/Contracts/Resources/CurrenciesContract.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Contracts\Resources;
+
+use EFinancialsClient\Responses\Currencies\ListResponse;
+
+interface CurrenciesContract
+{
+    /**
+     * Retrieve the active currencies of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/get-currencies
+     */
+    public function all(): ListResponse;
+}

--- a/src/Contracts/Resources/InvoicesContract.php
+++ b/src/Contracts/Resources/InvoicesContract.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Contracts\Resources;
+
+interface InvoicesContract
+{
+    /**
+     * Retrieve the invoice series list of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/get-invoice_series
+     */
+    public function all(): mixed;
+
+    /**
+     * Retrieve one specific invoice series of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/get-invoice_series_one
+     */
+    public function get(int $id): mixed;
+
+    /**
+     * Create a new invoice series of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/get-invoice_series
+     *
+     * @param array<string,mixed>|array{
+     *   "is_active": true,
+     *   "is_default": false,
+     *   "number_prefix": string,
+     *   "number_start_value": 1,
+     *   "term_days": 28,
+     *   "overdue_charge": 0.15,
+     * } $parameters
+     */
+    public function create(array $parameters = []): mixed;
+
+    /**
+     * Modify one specific invoice series of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/patch-invoice_series_one
+     *
+     * @param array<string,mixed>|array{
+     *   "is_active": true,
+     *   "is_default": false,
+     *   "number_prefix": string,
+     *   "number_start_value": 1,
+     *   "term_days": 28,
+     *   "overdue_charge": 0.15,
+     * } $parameters
+     */
+    public function update(int $id, array $parameters): mixed;
+
+    /**
+     * Delete one specific invoice series of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/delete-invoice_series_one
+     *
+     * @param  int  $id  Invoice series identificator.
+     */
+    public function delete(int $id): mixed;
+
+    /**
+     * Retrieve the invoice settings of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/get-invoice_info
+     */
+    public function allSettings(): mixed;
+
+    /**
+     * Update the invoice settings of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/patch-invoice_info
+     *
+     * @param array<string,mixed>|array{
+     *   "address": string,
+     *   "email": string,
+     *   "phone": string,
+     *   "fax": string,
+     *   "webpage": string,
+     *   "cl_templates_id": 1,
+     *   "invoice_company_name": string,
+     *   "invoice_email_subject": string,
+     *   "invoice_email_body": string,
+     *   "balance_email_subject": string,
+     *   "balance_email_body": string,
+     *   "balance_document_footer": string
+     * } $parameters
+     */
+    public function updateSettings(array $parameters): mixed;
+}

--- a/src/Contracts/Resources/JournalsContract.php
+++ b/src/Contracts/Resources/JournalsContract.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Contracts\Resources;
+
+use DateTime;
+
+interface JournalsContract
+{
+    /**
+     * Retrieve the journal entry list of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/get-journals
+     *
+     * @param  int  $page  Page of responses to return.
+     * @param  DateTime|string  $modifiedSince  Return only objects modified since provided timestamp.
+     * @param  DateTime|string  $startDate  Effective date on given date or later.
+     * @param  DateTime|string  $endDate  Effective date on given date or before.
+     */
+    public function all(int $page = 1, DateTime|string $modifiedSince = '', DateTime|string $startDate = '', DateTime|string $endDate = ''): mixed;
+
+    /**
+     * Retrieve one specific journal entry of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/get-journals_one
+     *
+     * @param  int  $id  Journal entry identificator.
+     */
+    public function get(int $id): mixed;
+
+    /**
+     * Create a new journal entry of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/post-journals
+     *
+     * @param array<string,mixed>|array{
+     *   "effective_date": "2014-05-31",
+     *   "postings": array,
+     *   "title": string,
+     *   "clients_id": int,
+     *   "cl_currencies_id": "EUR",
+     *   "document_number": string,
+     * } $parameters
+     */
+    public function create(array $parameters = []): mixed;
+
+    /**
+     * Modify one specific journal entry of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/patch-journals_one
+     *
+     * @param  int  $id  Journal entry identificator.
+     * @param array<string,mixed>|array{
+     *   "effective_date": "2014-05-31",
+     *   "postings": array,
+     *   "title": string,
+     *   "clients_id": int,
+     *   "cl_currencies_id": "EUR",
+     *   "document_number": string,
+     * } $parameters
+     */
+    public function update(int $id, array $parameters): mixed;
+
+    /**
+     * Delete one specific journal entry of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/delete-journals_one
+     *
+     * @param  int  $id  Journal entry identificator.
+     */
+    public function delete(int $id): mixed;
+
+    /**
+     * Register one specific journal entry of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/patch-journals_one_register
+     *
+     * @param  int  $id  Journal entry identificator.
+     */
+    public function register(int $id): mixed;
+
+    /**
+     * Invalidate one specific journal entry of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/patch-journals_one_invalidate
+     *
+     * @param  int  $id  Journal entry identificator.
+     */
+    public function invalidate(int $id): mixed;
+
+    /**
+     * Retrieve the document related to a journal entry of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/get-journals_one_document_user
+     *
+     * @param  int  $id  Journal entry identificator.
+     */
+    public function getFile(int $id): mixed;
+
+    /**
+     * Update the document related to a journal entry of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/put-journals_one_document_user
+     *
+     * @param  int  $id  Journal entry identificator.
+     * @param array<string,mixed>|array{
+     *   "name": string,
+     *   "contents": string,
+     * } $parameters Base64-encoded file payload.
+     */
+    public function updateFile(int $id, array $parameters): mixed;
+
+    /**
+     * Delete the document related to a journal entry of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/delete-journals_one_document_user
+     *
+     * @param  int  $id  Journal entry identificator.
+     */
+    public function deleteFile(int $id): mixed;
+}

--- a/src/Contracts/Resources/ProductsContract.php
+++ b/src/Contracts/Resources/ProductsContract.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Contracts\Resources;
+
+use DateTime;
+use EFinancialsClient\Responses\ApiResponse;
+use EFinancialsClient\Responses\Products\ListResponse;
+use EFinancialsClient\Responses\Products\ProductResponse;
+
+interface ProductsContract
+{
+    /**
+     * Retrieve the product list of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/get-products
+     *
+     * @param  int  $page  Page of responses to return.
+     * @param  DateTime|string  $modifiedSince  Return only objects modified since provided timestamp.
+     */
+    public function all(int $page = 1, DateTime|string $modifiedSince = ''): ListResponse;
+
+    /**
+     * Get a product.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/get-products_one
+     *
+     * @param  int  $id  Product identificator.
+     */
+    public function get(int $id): ProductResponse;
+
+    /**
+     * Create a product.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/post-products
+     *
+     * @param  array<string, mixed>  $parameters
+     */
+    public function create(string $name, string $code, array $parameters = []): ApiResponse;
+
+    /**
+     * Modify one specific product of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/patch-products_one
+     *
+     * @param  int  $id  Product identificator.
+     * @param  array<string, mixed>  $parameters
+     */
+    public function update(int $id, array $parameters = []): ApiResponse;
+
+    /**
+     * Delete one specific product of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/delete-products_one
+     *
+     * @param  int  $id  Product identificator.
+     */
+    public function delete(int $id): ApiResponse;
+
+    /**
+     * Deactivate one specific product of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/patch-products_one_deactivate
+     *
+     * @param  int  $id  Product identificator.
+     */
+    public function deactivate(int $id): ApiResponse;
+
+    /**
+     * Reactivate one specific product of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/patch-products_one_reactivate
+     *
+     * @param  int  $id  Product identificator.
+     */
+    public function reactivate(int $id): ApiResponse;
+}

--- a/src/Contracts/Resources/PurchaseArticlesContract.php
+++ b/src/Contracts/Resources/PurchaseArticlesContract.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Contracts\Resources;
+
+use EFinancialsClient\Responses\PurchaseArticles\ListResponse;
+
+interface PurchaseArticlesContract
+{
+    /**
+     * Retrieve the purchase articles of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/get-purchase_articles
+     */
+    public function all(): ListResponse;
+}

--- a/src/Contracts/Resources/PurchaseInvoicesContract.php
+++ b/src/Contracts/Resources/PurchaseInvoicesContract.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Contracts\Resources;
+
+use DateTime;
+
+interface PurchaseInvoicesContract
+{
+    /**
+     * Retrieve the purchase invoice list of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/get-purchase_invoices
+     *
+     * @param  int  $page  Page of responses to return.
+     * @param  DateTime|string  $modifiedSince  Return only objects modified since provided timestamp.
+     * @param  DateTime|string  $startDate  Object created on given date or later.
+     * @param  DateTime|string  $endDate  Object created on given date or before.
+     * @param  string  $status  Object status.
+     * @param  string  $paymentStatus  Object payment status.
+     * @param  int|null  $clientsId  Supplier identificator.
+     */
+    public function all(int $page = 1, DateTime|string $modifiedSince = '', DateTime|string $startDate = '', DateTime|string $endDate = '', string $status = '', string $paymentStatus = '', ?int $clientsId = null): mixed;
+
+    /**
+     * Retrieve one specific purchase invoice of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/get-purchase_invoices_one
+     *
+     * @param  int  $id  Purchase invoice identificator.
+     */
+    public function get(int $id): mixed;
+
+    /**
+     * Create a new purchase invoice of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/post-purchase_invoices
+     *
+     * @param array<string,mixed>|array{
+     *   "clients_id": 803,
+     *   "client_name": string,
+     *   "number": string,
+     *   "create_date": "2017-08-09",
+     *   "journal_date": "2017-08-09",
+     *   "term_days": 0,
+     *   "cl_currencies_id": "EUR"
+     * } $parameters
+     */
+    public function create(array $parameters = []): mixed;
+
+    /**
+     * Modify one specific purchase invoice of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/patch-purchase_invoices_one
+     *
+     * @param  int  $id  Purchase invoice identificator.
+     * @param array<string,mixed>|array{
+     *   "clients_id": 803,
+     *   "client_name": string,
+     *   "number": string,
+     *   "create_date": "2017-08-09",
+     *   "journal_date": "2017-08-09",
+     *   "term_days": 0,
+     *   "cl_currencies_id": "EUR"
+     * } $parameters
+     */
+    public function update(int $id, array $parameters): mixed;
+
+    /**
+     * Delete one specific purchase invoice of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/delete-purchase_invoices_one
+     *
+     * @param  int  $id  Purchase invoice identificator.
+     */
+    public function delete(int $id): mixed;
+
+    /**
+     * Register one specific purchase invoice of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/patch-purchase_invoices_one_register
+     *
+     * @param  int  $id  Purchase invoice identificator.
+     */
+    public function register(int $id): mixed;
+
+    /**
+     * Invalidate one specific purchase invoice of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/patch-purchase_invoices_one_invalidate
+     *
+     * @param  int  $id  Purchase invoice identificator.
+     */
+    public function invalidate(int $id): mixed;
+
+    /**
+     * Retrieve the user-uploaded document related to a purchase invoice.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/get-purchase_invoices_one_document_user
+     *
+     * @param  int  $id  Purchase invoice identificator.
+     */
+    public function getFile(int $id): mixed;
+
+    /**
+     * Update the user-uploaded document related to a purchase invoice.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/put-purchase_invoices_one_document_user
+     *
+     * @param  int  $id  Purchase invoice identificator.
+     * @param array<string,mixed>|array{
+     *   "name": string,
+     *   "contents": string,
+     * } $parameters Base64-encoded file payload.
+     */
+    public function updateFile(int $id, array $parameters): mixed;
+
+    /**
+     * Delete the user-uploaded document related to a purchase invoice.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/delete-purchase_invoices_one_document_user
+     *
+     * @param  int  $id  Purchase invoice identificator.
+     */
+    public function deleteFile(int $id): mixed;
+}

--- a/src/Contracts/Resources/SalesArticlesContract.php
+++ b/src/Contracts/Resources/SalesArticlesContract.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Contracts\Resources;
+
+use EFinancialsClient\Responses\SalesArticles\ListResponse;
+
+interface SalesArticlesContract
+{
+    /**
+     * Retrieve the sale articles of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/get-sale_articles
+     */
+    public function all(): ListResponse;
+}

--- a/src/Contracts/Resources/SalesInvoicesContract.php
+++ b/src/Contracts/Resources/SalesInvoicesContract.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Contracts\Resources;
+
+use DateTime;
+
+interface SalesInvoicesContract
+{
+    /**
+     * Retrieve the sale invoice list of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/get-sale_invoices
+     *
+     * @param  int  $page  Page of responses to return.
+     * @param  DateTime|string  $modifiedSince  Return only objects modified since provided timestamp.
+     * @param  DateTime|string  $startDate  Object revenue date on given date or later.
+     * @param  DateTime|string  $endDate  Object revenue date on given date or before.
+     * @param  string  $status  Object status.
+     * @param  string  $paymentStatus  Object payment status.
+     * @param  int|null  $clientsId  Customer identificator.
+     */
+    public function all(int $page = 1, DateTime|string $modifiedSince = '', DateTime|string $startDate = '', DateTime|string $endDate = '', string $status = '', string $paymentStatus = '', ?int $clientsId = null): mixed;
+
+    /**
+     * Retrieve one specific sale invoice of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/get-sale_invoices_one
+     *
+     * @param  int  $id  Sale invoice identificator.
+     */
+    public function get(int $id): mixed;
+
+    /**
+     * Create a new sale invoice of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/post-sale_invoices
+     *
+     * @param array<string,mixed>|array{
+     *   "sale_invoice_type": "INVOICE",
+     *   "cl_templates_id": 1,
+     *   "clients_id": 126,
+     *   "cl_countries_id": "EST",
+     *   "number_suffix": "91",
+     *   "create_date": "2016-02-15",
+     *   "journal_date": "2016-02-15",
+     *   "term_days": 30,
+     *   "cl_currencies_id": "EUR",
+     *   "show_client_balance": false
+     * } $parameters
+     */
+    public function create(array $parameters = []): mixed;
+
+    /**
+     * Modify one specific sale invoice of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/patch-sale_invoices_one
+     *
+     * @param  int  $id  Sale invoice identificator.
+     * @param array<string,mixed>|array{
+     *   "sale_invoice_type": "INVOICE",
+     *   "cl_templates_id": 1,
+     *   "clients_id": 126,
+     *   "cl_countries_id": "EST",
+     *   "number_suffix": "91",
+     *   "create_date": "2016-02-15",
+     *   "journal_date": "2016-02-15",
+     *   "term_days": 30,
+     *   "cl_currencies_id": "EUR",
+     *   "show_client_balance": false
+     * } $parameters
+     */
+    public function update(int $id, array $parameters): mixed;
+
+    /**
+     * Delete one specific sale invoice of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/delete-sale_invoices_one
+     *
+     * @param  int  $id  Sale invoice identificator.
+     */
+    public function delete(int $id): mixed;
+
+    /**
+     * Register one specific sale invoice of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/patch-sale_invoices_one_register
+     *
+     * @param  int  $id  Sale invoice identificator.
+     */
+    public function register(int $id): mixed;
+
+    /**
+     * Invalidate one specific sale invoice of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/patch-sale_invoices_one_invalidate
+     *
+     * @param  int  $id  Sale invoice identificator.
+     */
+    public function invalidate(int $id): mixed;
+
+    /**
+     * Retrieve the system-generated XML e-invoice related to a sale invoice.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/get-sale_invoices_one_xml
+     *
+     * @param  int  $id  Sale invoice identificator.
+     */
+    public function getXml(int $id): mixed;
+
+    /**
+     * Retrieve the system-generated PDF related to a sale invoice.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/get-sale_invoices_one_document_system
+     *
+     * @param  int  $id  Sale invoice identificator.
+     */
+    public function getSystemPdf(int $id): mixed;
+
+    /**
+     * Retrieve the user-uploaded document related to a sale invoice.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/get-sale_invoices_one_document_user
+     *
+     * @param  int  $id  Sale invoice identificator.
+     */
+    public function getFile(int $id): mixed;
+
+    /**
+     * Update the user-uploaded document related to a sale invoice.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/put-sale_invoices_one_document_user
+     *
+     * @param  int  $id  Sale invoice identificator.
+     * @param array<string,mixed>|array{
+     *   "name": string,
+     *   "contents": string,
+     * } $parameters Base64-encoded file payload.
+     */
+    public function updateFile(int $id, array $parameters): mixed;
+
+    /**
+     * Delete the user-uploaded document related to a sale invoice.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/delete-sale_invoices_one_document_user
+     *
+     * @param  int  $id  Sale invoice identificator.
+     */
+    public function deleteFile(int $id): mixed;
+
+    /**
+     * Retrieve delivery options for one specific sale invoice.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/get-sale_invoices_one_delivery_opts
+     *
+     * @param  int  $id  Sale invoice identificator.
+     */
+    public function getDeliveryOptions(int $id): mixed;
+
+    /**
+     * Send one specific sale invoice to the customer.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/patch-sale_invoices_one_deliver
+     *
+     * @param  int  $id  Sale invoice identificator.
+     * @param array<string,mixed>|array{
+     *   "send_einvoice": bool,
+     *   "send_email": bool,
+     *   "email_addresses": string,
+     *   "email_subject": string,
+     *   "email_body": string,
+     * } $parameters
+     */
+    public function deliver(int $id, array $parameters): mixed;
+}

--- a/src/Contracts/Resources/TemplatesContract.php
+++ b/src/Contracts/Resources/TemplatesContract.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Contracts\Resources;
+
+use EFinancialsClient\Responses\Templates\ListResponse;
+
+interface TemplatesContract
+{
+    /**
+     * Retrieve sale invoice templates of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/get-templates
+     */
+    public function all(): ListResponse;
+}

--- a/src/Contracts/Resources/TransactionsContract.php
+++ b/src/Contracts/Resources/TransactionsContract.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Contracts\Resources;
+
+use DateTime;
+
+interface TransactionsContract
+{
+    /**
+     * Retrieve the transaction list of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/get-transactions
+     *
+     * @param  int  $page  Page of responses to return.
+     * @param  DateTime|string  $modifiedSince  Return only objects modified since provided timestamp.
+     * @param  DateTime|string  $startDate  Date on given date or later.
+     * @param  DateTime|string  $endDate  Date on given date or before.
+     * @param  string  $status  Object status.
+     * @param  string  $type  Object type.
+     * @param  int|null  $clientsId  Customer identificator.
+     */
+    public function all(int $page = 1, DateTime|string $modifiedSince = '', DateTime|string $startDate = '', DateTime|string $endDate = '', string $status = '', string $type = '', ?int $clientsId = null): mixed;
+
+    /**
+     * Retrieve one specific transaction of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/get-transactions_one
+     *
+     * @param  int  $id  Transaction identificator.
+     */
+    public function get(int $id): mixed;
+
+    /**
+     * Create a new transaction of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/post-transactions
+     *
+     * @param array<string,mixed>|array{
+     *   "accounts_dimensions_id": int,
+     *   "type": "D"|"C",
+     *   "amount": float,
+     *   "cl_currencies_id": "EUR",
+     *   "date": "2015-01-31",
+     *   "description": string,
+     *   "clients_id": int,
+     * } $parameters
+     */
+    public function create(array $parameters = []): mixed;
+
+    /**
+     * Modify one specific transaction of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/patch-transactions_one
+     *
+     * @param  int  $id  Transaction identificator.
+     * @param array<string,mixed>|array{
+     *   "accounts_dimensions_id": int,
+     *   "type": "D"|"C",
+     *   "amount": float,
+     *   "cl_currencies_id": "EUR",
+     *   "date": "2015-01-31",
+     *   "description": string,
+     *   "clients_id": int,
+     * } $parameters
+     */
+    public function update(int $id, array $parameters): mixed;
+
+    /**
+     * Delete one specific transaction of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/delete-transactions_one
+     *
+     * @param  int  $id  Transaction identificator.
+     */
+    public function delete(int $id): mixed;
+
+    /**
+     * Register one specific transaction of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/patch-transactions_one_register
+     *
+     * @param  int  $id  Transaction identificator.
+     * @param  array<int, mixed>  $distributions  Optional transaction distribution rows.
+     */
+    public function register(int $id, array $distributions = []): mixed;
+
+    /**
+     * Invalidate one specific transaction of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/patch-transactions_one_invalidate
+     *
+     * @param  int  $id  Transaction identificator.
+     */
+    public function invalidate(int $id): mixed;
+
+    /**
+     * Retrieve the document related to a transaction of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/get-transactions_one_document_user
+     *
+     * @param  int  $id  Transaction identificator.
+     */
+    public function getFile(int $id): mixed;
+
+    /**
+     * Update the document related to a transaction of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/put-transactions_one_document_user
+     *
+     * @param  int  $id  Transaction identificator.
+     * @param array<string,mixed>|array{
+     *   "name": string,
+     *   "contents": string,
+     * } $parameters Base64-encoded file payload.
+     */
+    public function updateFile(int $id, array $parameters): mixed;
+
+    /**
+     * Delete the document related to a transaction of the specified company.
+     *
+     * @see https://rmp-api.rik.ee/api.html#operation/delete-transactions_one_document_user
+     *
+     * @param  int  $id  Transaction identificator.
+     */
+    public function deleteFile(int $id): mixed;
+}

--- a/src/Resources/AccountDimensions.php
+++ b/src/Resources/AccountDimensions.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace EFinancialsClient\Resources;
 
+use EFinancialsClient\Contracts\Resources\AccountDimensionsContract;
 use EFinancialsClient\Resources\Concerns\Transportable;
 use EFinancialsClient\Responses\AccountDimensions\ListResponse;
 use EFinancialsClient\ValueObjects\Transporter\Payload;
 use EFinancialsClient\ValueObjects\Transporter\Response;
 
-final class AccountDimensions
+final class AccountDimensions implements AccountDimensionsContract
 {
     use Transportable;
 

--- a/src/Resources/Accounts.php
+++ b/src/Resources/Accounts.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace EFinancialsClient\Resources;
 
+use EFinancialsClient\Contracts\Resources\AccountsContract;
 use EFinancialsClient\Resources\Concerns\Transportable;
 use EFinancialsClient\Responses\Accounts\ListResponse;
 use EFinancialsClient\ValueObjects\Transporter\Payload;
 use EFinancialsClient\ValueObjects\Transporter\Response;
 
-final class Accounts
+final class Accounts implements AccountsContract
 {
     use Transportable;
 

--- a/src/Resources/Bank.php
+++ b/src/Resources/Bank.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace EFinancialsClient\Resources;
 
+use EFinancialsClient\Contracts\Resources\BankContract;
 use EFinancialsClient\Resources\Concerns\Transportable;
 use EFinancialsClient\Responses\ApiResponse;
 use EFinancialsClient\Responses\Bank\BankAccountResponse;
@@ -13,7 +14,7 @@ use EFinancialsClient\ValueObjects\Transporter\Payload;
 use EFinancialsClient\ValueObjects\Transporter\Response;
 use InvalidArgumentException;
 
-final class Bank
+final class Bank implements BankContract
 {
     use Transportable;
 

--- a/src/Resources/Clients.php
+++ b/src/Resources/Clients.php
@@ -6,6 +6,7 @@ namespace EFinancialsClient\Resources;
 
 use DateTime;
 use DateTimeInterface;
+use EFinancialsClient\Contracts\Resources\ClientsContract;
 use EFinancialsClient\Resources\Concerns\Transportable;
 use EFinancialsClient\Responses\ApiResponse;
 use EFinancialsClient\Responses\Clients\ClientResponse;
@@ -14,7 +15,7 @@ use EFinancialsClient\ValueObjects\Transporter\Payload;
 use EFinancialsClient\ValueObjects\Transporter\Response;
 use InvalidArgumentException;
 
-final class Clients
+final class Clients implements ClientsContract
 {
     use Transportable;
 

--- a/src/Resources/CostProfitCentres.php
+++ b/src/Resources/CostProfitCentres.php
@@ -6,12 +6,13 @@ namespace EFinancialsClient\Resources;
 
 use DateTime;
 use DateTimeInterface;
+use EFinancialsClient\Contracts\Resources\CostProfitCentresContract;
 use EFinancialsClient\Resources\Concerns\Transportable;
 use EFinancialsClient\Responses\CostProfitCentres\ListResponse;
 use EFinancialsClient\ValueObjects\Transporter\Payload;
 use EFinancialsClient\ValueObjects\Transporter\Response;
 
-final class CostProfitCentres
+final class CostProfitCentres implements CostProfitCentresContract
 {
     use Transportable;
 

--- a/src/Resources/Currencies.php
+++ b/src/Resources/Currencies.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace EFinancialsClient\Resources;
 
+use EFinancialsClient\Contracts\Resources\CurrenciesContract;
 use EFinancialsClient\Resources\Concerns\Transportable;
 use EFinancialsClient\Responses\Currencies\ListResponse;
 use EFinancialsClient\ValueObjects\Transporter\Payload;
 use EFinancialsClient\ValueObjects\Transporter\Response;
 
-final class Currencies
+final class Currencies implements CurrenciesContract
 {
     use Transportable;
 

--- a/src/Resources/Invoices.php
+++ b/src/Resources/Invoices.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace EFinancialsClient\Resources;
 
+use EFinancialsClient\Contracts\Resources\InvoicesContract;
 use EFinancialsClient\Resources\Concerns\Transportable;
 use EFinancialsClient\ValueObjects\Transporter\Payload;
 
-final class Invoices
+final class Invoices implements InvoicesContract
 {
     use Transportable;
 

--- a/src/Resources/Journals.php
+++ b/src/Resources/Journals.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace EFinancialsClient\Resources;
 
 use DateTime;
+use EFinancialsClient\Contracts\Resources\JournalsContract;
 use EFinancialsClient\Resources\Concerns\Transportable;
 use EFinancialsClient\ValueObjects\Transporter\Payload;
 
-final class Journals
+final class Journals implements JournalsContract
 {
     use Transportable;
 

--- a/src/Resources/Products.php
+++ b/src/Resources/Products.php
@@ -6,6 +6,7 @@ namespace EFinancialsClient\Resources;
 
 use DateTime;
 use DateTimeInterface;
+use EFinancialsClient\Contracts\Resources\ProductsContract;
 use EFinancialsClient\Resources\Concerns\Transportable;
 use EFinancialsClient\Responses\ApiResponse;
 use EFinancialsClient\Responses\Products\ListResponse;
@@ -14,7 +15,7 @@ use EFinancialsClient\ValueObjects\Transporter\Payload;
 use EFinancialsClient\ValueObjects\Transporter\Response;
 use InvalidArgumentException;
 
-final class Products
+final class Products implements ProductsContract
 {
     use Transportable;
 

--- a/src/Resources/PurchaseArticles.php
+++ b/src/Resources/PurchaseArticles.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace EFinancialsClient\Resources;
 
+use EFinancialsClient\Contracts\Resources\PurchaseArticlesContract;
 use EFinancialsClient\Resources\Concerns\Transportable;
 use EFinancialsClient\Responses\PurchaseArticles\ListResponse;
 use EFinancialsClient\ValueObjects\Transporter\Payload;
 use EFinancialsClient\ValueObjects\Transporter\Response;
 
-final class PurchaseArticles
+final class PurchaseArticles implements PurchaseArticlesContract
 {
     use Transportable;
 

--- a/src/Resources/PurchaseInvoices.php
+++ b/src/Resources/PurchaseInvoices.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace EFinancialsClient\Resources;
 
 use DateTime;
+use EFinancialsClient\Contracts\Resources\PurchaseInvoicesContract;
 use EFinancialsClient\Resources\Concerns\Transportable;
 use EFinancialsClient\ValueObjects\Transporter\Payload;
 
-final class PurchaseInvoices
+final class PurchaseInvoices implements PurchaseInvoicesContract
 {
     use Transportable;
 

--- a/src/Resources/SalesArticles.php
+++ b/src/Resources/SalesArticles.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace EFinancialsClient\Resources;
 
+use EFinancialsClient\Contracts\Resources\SalesArticlesContract;
 use EFinancialsClient\Resources\Concerns\Transportable;
 use EFinancialsClient\Responses\SalesArticles\ListResponse;
 use EFinancialsClient\ValueObjects\Transporter\Payload;
 use EFinancialsClient\ValueObjects\Transporter\Response;
 
-final class SalesArticles
+final class SalesArticles implements SalesArticlesContract
 {
     use Transportable;
 

--- a/src/Resources/SalesInvoices.php
+++ b/src/Resources/SalesInvoices.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace EFinancialsClient\Resources;
 
 use DateTime;
+use EFinancialsClient\Contracts\Resources\SalesInvoicesContract;
 use EFinancialsClient\Resources\Concerns\Transportable;
 use EFinancialsClient\ValueObjects\Transporter\Payload;
 
-final class SalesInvoices
+final class SalesInvoices implements SalesInvoicesContract
 {
     use Transportable;
 

--- a/src/Resources/Templates.php
+++ b/src/Resources/Templates.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace EFinancialsClient\Resources;
 
+use EFinancialsClient\Contracts\Resources\TemplatesContract;
 use EFinancialsClient\Resources\Concerns\Transportable;
 use EFinancialsClient\Responses\Templates\ListResponse;
 use EFinancialsClient\ValueObjects\Transporter\Payload;
 use EFinancialsClient\ValueObjects\Transporter\Response;
 
-final class Templates
+final class Templates implements TemplatesContract
 {
     use Transportable;
 

--- a/src/Resources/Transactions.php
+++ b/src/Resources/Transactions.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace EFinancialsClient\Resources;
 
 use DateTime;
+use EFinancialsClient\Contracts\Resources\TransactionsContract;
 use EFinancialsClient\Resources\Concerns\Transportable;
 use EFinancialsClient\ValueObjects\Transporter\Payload;
 
-final class Transactions
+final class Transactions implements TransactionsContract
 {
     use Transportable;
 

--- a/src/Testing/ClientFake.php
+++ b/src/Testing/ClientFake.php
@@ -5,6 +5,21 @@ declare(strict_types=1);
 namespace EFinancialsClient\Testing;
 
 use EFinancialsClient\Contracts\ClientContract;
+use EFinancialsClient\Contracts\Resources\AccountDimensionsContract;
+use EFinancialsClient\Contracts\Resources\AccountsContract;
+use EFinancialsClient\Contracts\Resources\BankContract;
+use EFinancialsClient\Contracts\Resources\ClientsContract;
+use EFinancialsClient\Contracts\Resources\CostProfitCentresContract;
+use EFinancialsClient\Contracts\Resources\CurrenciesContract;
+use EFinancialsClient\Contracts\Resources\InvoicesContract;
+use EFinancialsClient\Contracts\Resources\JournalsContract;
+use EFinancialsClient\Contracts\Resources\ProductsContract;
+use EFinancialsClient\Contracts\Resources\PurchaseArticlesContract;
+use EFinancialsClient\Contracts\Resources\PurchaseInvoicesContract;
+use EFinancialsClient\Contracts\Resources\SalesArticlesContract;
+use EFinancialsClient\Contracts\Resources\SalesInvoicesContract;
+use EFinancialsClient\Contracts\Resources\TemplatesContract;
+use EFinancialsClient\Contracts\Resources\TransactionsContract;
 use EFinancialsClient\Contracts\ResponseContract;
 use EFinancialsClient\Resources\AccountDimensions;
 use EFinancialsClient\Resources\Accounts;
@@ -86,77 +101,77 @@ final class ClientFake implements ClientContract
         ));
     }
 
-    public function accountDimensions(): AccountDimensions
+    public function accountDimensions(): AccountDimensionsContract
     {
         return new AccountDimensions($this->transporter);
     }
 
-    public function accounts(): Accounts
+    public function accounts(): AccountsContract
     {
         return new Accounts($this->transporter);
     }
 
-    public function bank(): Bank
+    public function bank(): BankContract
     {
         return new Bank($this->transporter);
     }
 
-    public function clients(): Clients
+    public function clients(): ClientsContract
     {
         return new Clients($this->transporter);
     }
 
-    public function costProfitCentres(): CostProfitCentres
+    public function costProfitCentres(): CostProfitCentresContract
     {
         return new CostProfitCentres($this->transporter);
     }
 
-    public function currencies(): Currencies
+    public function currencies(): CurrenciesContract
     {
         return new Currencies($this->transporter);
     }
 
-    public function invoices(): Invoices
+    public function invoices(): InvoicesContract
     {
         return new Invoices($this->transporter);
     }
 
-    public function journals(): Journals
+    public function journals(): JournalsContract
     {
         return new Journals($this->transporter);
     }
 
-    public function products(): Products
+    public function products(): ProductsContract
     {
         return new Products($this->transporter);
     }
 
-    public function purchaseArticles(): PurchaseArticles
+    public function purchaseArticles(): PurchaseArticlesContract
     {
         return new PurchaseArticles($this->transporter);
     }
 
-    public function purchaseInvoices(): PurchaseInvoices
+    public function purchaseInvoices(): PurchaseInvoicesContract
     {
         return new PurchaseInvoices($this->transporter);
     }
 
-    public function salesArticles(): SalesArticles
+    public function salesArticles(): SalesArticlesContract
     {
         return new SalesArticles($this->transporter);
     }
 
-    public function salesInvoices(): SalesInvoices
+    public function salesInvoices(): SalesInvoicesContract
     {
         return new SalesInvoices($this->transporter);
     }
 
-    public function templates(): Templates
+    public function templates(): TemplatesContract
     {
         return new Templates($this->transporter);
     }
 
-    public function transactions(): Transactions
+    public function transactions(): TransactionsContract
     {
         return new Transactions($this->transporter);
     }

--- a/tests/Arch.php
+++ b/tests/Arch.php
@@ -1,6 +1,7 @@
 <?php
 
 test('resources')->expect('EFinancialsClient\Resources')->toOnlyUse([
+    'EFinancialsClient\Contracts\Resources',
     'EFinancialsClient\Contracts\TransporterContract',
     'EFinancialsClient\Resources\Concerns\Transportable',
     'EFinancialsClient\Responses',
@@ -13,6 +14,7 @@ test('resources')->expect('EFinancialsClient\Resources')->toOnlyUse([
 
 test('client')->expect('EFinancialsClient\Client')->toOnlyUse([
     'EFinancialsClient\Contracts\ClientContract',
+    'EFinancialsClient\Contracts\Resources',
     'EFinancialsClient\Contracts\TransporterContract',
     'EFinancialsClient\Resources',
 ]);
@@ -32,3 +34,7 @@ test('resources are final')
     ->classes()
     ->toBeFinal()
     ->ignoring('EFinancialsClient\Resources\Concerns\Transportable');
+
+test('resource contracts are interfaces')
+    ->expect('EFinancialsClient\Contracts\Resources')
+    ->toBeInterfaces();

--- a/tests/Client.php
+++ b/tests/Client.php
@@ -1,13 +1,13 @@
 <?php
 
 use EFinancialsClient\Client;
+use EFinancialsClient\Contracts\Resources\ClientsContract;
+use EFinancialsClient\Contracts\Resources\JournalsContract;
+use EFinancialsClient\Contracts\Resources\PurchaseInvoicesContract;
+use EFinancialsClient\Contracts\Resources\SalesInvoicesContract;
+use EFinancialsClient\Contracts\Resources\TemplatesContract;
+use EFinancialsClient\Contracts\Resources\TransactionsContract;
 use EFinancialsClient\Exceptions\ErrorException;
-use EFinancialsClient\Resources\Clients;
-use EFinancialsClient\Resources\Journals;
-use EFinancialsClient\Resources\PurchaseInvoices;
-use EFinancialsClient\Resources\SalesInvoices;
-use EFinancialsClient\Resources\Templates;
-use EFinancialsClient\Resources\Transactions;
 use EFinancialsClient\Responses\Accounts\AccountResponse;
 use EFinancialsClient\Responses\Accounts\ListResponse as AccountsListResponse;
 use EFinancialsClient\Responses\ApiFileResponse;
@@ -84,12 +84,12 @@ it('exposes resource accessors', function () {
         ->withHttpClient(HttpClientFake::sequence([]))
         ->make();
 
-    expect($client->clients())->toBeInstanceOf(Clients::class)
-        ->and($client->journals())->toBeInstanceOf(Journals::class)
-        ->and($client->salesInvoices())->toBeInstanceOf(SalesInvoices::class)
-        ->and($client->purchaseInvoices())->toBeInstanceOf(PurchaseInvoices::class)
-        ->and($client->transactions())->toBeInstanceOf(Transactions::class)
-        ->and($client->templates())->toBeInstanceOf(Templates::class);
+    expect($client->clients())->toBeInstanceOf(ClientsContract::class)
+        ->and($client->journals())->toBeInstanceOf(JournalsContract::class)
+        ->and($client->salesInvoices())->toBeInstanceOf(SalesInvoicesContract::class)
+        ->and($client->purchaseInvoices())->toBeInstanceOf(PurchaseInvoicesContract::class)
+        ->and($client->transactions())->toBeInstanceOf(TransactionsContract::class)
+        ->and($client->templates())->toBeInstanceOf(TemplatesContract::class);
 });
 
 it('maps currencies to a typed list response', function () {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

PR 4 from the post-#90 plan: openai-php-style per-resource contracts so `ClientContract` no longer returns concrete resource classes.

### Changes
1. **`Contracts/Resources/*Contract`** — one interface per resource (15 total), mirroring current public methods and return types (typed where DTOs exist; `mixed` elsewhere).
2. **Resources** — each `final class` now `implements` its contract.
3. **`ClientContract` / `Client` / `ClientFake`** — accessors return `*Contract` interfaces while still constructing concrete resource classes.
4. **Arch** — Resources may depend on `Contracts\Resources`; Client may depend on resource contracts; new assertion that resource contracts are interfaces.
5. **Tests** — accessor coverage asserts contract interfaces.

### Out of scope
- ClientFake redesign (PR5)
- Remaining Response DTOs (Invoices / Journals / Transactions / invoice families)
- Payload path helpers

### Verification
- `composer test` green (lint, PHPStan, type coverage, Pest)
- Demo API integration green

### What
- [ ] Bug Fix
- [x] New Feature

### Description
Add per-resource contracts and wire Client/ClientFake accessors to return them.

### Related
Follow-up to #91 / #93 / #95; deferred from #90

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc292-2ac0-79d0-9014-6126f82761ad?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc292-2ac0-79d0-9014-6126f82761ad&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

