### PR TITLE
refactor: redesign ClientFake around composed Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ $client = EFinancials::client('api_key_id', 'api_key_public', 'api_key_password'
 
 ## Testing with ClientFake
 
+`ClientFake` implements `ClientContract` by composing the real `Client` with a fake transporter. Queue response DTOs, arrays, JSON strings, or throwables, then assert on exact request paths.
+
 ```php
 use EFinancialsClient\Responses\Currencies\ListResponse;
 use EFinancialsClient\Testing\ClientFake;
@@ -60,6 +62,7 @@ $client = new ClientFake([
 
 $response = $client->currencies()->all();
 $client->assertSent('currencies');
+$client->assertSentTimes('currencies', 1);
 ```
 
 ## Development

--- a/src/Testing/ClientFake.php
+++ b/src/Testing/ClientFake.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace EFinancialsClient\Testing;
 
+use EFinancialsClient\Client;
 use EFinancialsClient\Contracts\ClientContract;
 use EFinancialsClient\Contracts\Resources\AccountDimensionsContract;
 use EFinancialsClient\Contracts\Resources\AccountsContract;
@@ -21,28 +22,16 @@ use EFinancialsClient\Contracts\Resources\SalesInvoicesContract;
 use EFinancialsClient\Contracts\Resources\TemplatesContract;
 use EFinancialsClient\Contracts\Resources\TransactionsContract;
 use EFinancialsClient\Contracts\ResponseContract;
-use EFinancialsClient\Resources\AccountDimensions;
-use EFinancialsClient\Resources\Accounts;
-use EFinancialsClient\Resources\Bank;
-use EFinancialsClient\Resources\Clients;
-use EFinancialsClient\Resources\CostProfitCentres;
-use EFinancialsClient\Resources\Currencies;
-use EFinancialsClient\Resources\Invoices;
-use EFinancialsClient\Resources\Journals;
-use EFinancialsClient\Resources\Products;
-use EFinancialsClient\Resources\PurchaseArticles;
-use EFinancialsClient\Resources\PurchaseInvoices;
-use EFinancialsClient\Resources\SalesArticles;
-use EFinancialsClient\Resources\SalesInvoices;
-use EFinancialsClient\Resources\Templates;
-use EFinancialsClient\Resources\Transactions;
 use EFinancialsClient\ValueObjects\Transporter\Payload;
+use EFinancialsClient\ValueObjects\Transporter\Response;
 use PHPUnit\Framework\Assert as PHPUnit;
 use Throwable;
 
 final class ClientFake implements ClientContract
 {
-    private TransporterFake $transporter;
+    private readonly TransporterFake $transporter;
+
+    private readonly Client $client;
 
     /**
      * @param  array<int, ResponseContract|array<array-key, mixed>|string|Throwable>  $responses
@@ -50,6 +39,7 @@ final class ClientFake implements ClientContract
     public function __construct(array $responses = [])
     {
         $this->transporter = new TransporterFake($responses);
+        $this->client = new Client($this->transporter);
     }
 
     /**
@@ -60,11 +50,44 @@ final class ClientFake implements ClientContract
         $this->transporter->addResponses($responses);
     }
 
-    public function assertSent(string $resource, ?callable $callback = null): void
+    /**
+     * @return array<int, Payload>
+     */
+    public function recorded(): array
     {
+        return $this->transporter->recorded();
+    }
+
+    /**
+     * @return array<int, array{0: Payload, 1: Response}>
+     */
+    public function recordedPairs(): array
+    {
+        return $this->transporter->recordedPairs();
+    }
+
+    public function assertSent(string $resource, callable|int|null $callback = null): void
+    {
+        if (is_int($callback)) {
+            $this->assertSentTimes($resource, $callback);
+
+            return;
+        }
+
         PHPUnit::assertTrue(
             $this->sent($resource, $callback) !== [],
             "The expected [{$resource}] request was not sent."
+        );
+    }
+
+    public function assertSentTimes(string $resource, int $times, ?callable $callback = null): void
+    {
+        $count = count($this->sent($resource, $callback));
+
+        PHPUnit::assertSame(
+            $times,
+            $count,
+            "The expected [{$resource}] request was sent {$count} times instead of {$times} times."
         );
     }
 
@@ -79,7 +102,15 @@ final class ClientFake implements ClientContract
 
     public function assertNothingSent(): void
     {
-        PHPUnit::assertEmpty($this->transporter->recorded(), 'Unexpected requests were sent.');
+        $resources = array_map(
+            static fn (Payload $payload): string => $payload->resource(),
+            $this->transporter->recorded(),
+        );
+
+        PHPUnit::assertEmpty(
+            $resources,
+            'The following requests were sent unexpectedly: '.implode(', ', $resources)
+        );
     }
 
     /**
@@ -88,11 +119,12 @@ final class ClientFake implements ClientContract
     private function sent(string $resource, ?callable $callback = null): array
     {
         $callback ??= static fn (Payload $payload): bool => true;
+        $expected = ltrim($resource, '/');
 
         return array_values(array_filter(
             $this->transporter->recorded(),
-            static function (Payload $payload) use ($resource, $callback): bool {
-                if (! str_starts_with(ltrim($payload->resource(), '/'), ltrim($resource, '/'))) {
+            static function (Payload $payload) use ($expected, $callback): bool {
+                if (ltrim($payload->resource(), '/') !== $expected) {
                     return false;
                 }
 
@@ -103,76 +135,76 @@ final class ClientFake implements ClientContract
 
     public function accountDimensions(): AccountDimensionsContract
     {
-        return new AccountDimensions($this->transporter);
+        return $this->client->accountDimensions();
     }
 
     public function accounts(): AccountsContract
     {
-        return new Accounts($this->transporter);
+        return $this->client->accounts();
     }
 
     public function bank(): BankContract
     {
-        return new Bank($this->transporter);
+        return $this->client->bank();
     }
 
     public function clients(): ClientsContract
     {
-        return new Clients($this->transporter);
+        return $this->client->clients();
     }
 
     public function costProfitCentres(): CostProfitCentresContract
     {
-        return new CostProfitCentres($this->transporter);
+        return $this->client->costProfitCentres();
     }
 
     public function currencies(): CurrenciesContract
     {
-        return new Currencies($this->transporter);
+        return $this->client->currencies();
     }
 
     public function invoices(): InvoicesContract
     {
-        return new Invoices($this->transporter);
+        return $this->client->invoices();
     }
 
     public function journals(): JournalsContract
     {
-        return new Journals($this->transporter);
+        return $this->client->journals();
     }
 
     public function products(): ProductsContract
     {
-        return new Products($this->transporter);
+        return $this->client->products();
     }
 
     public function purchaseArticles(): PurchaseArticlesContract
     {
-        return new PurchaseArticles($this->transporter);
+        return $this->client->purchaseArticles();
     }
 
     public function purchaseInvoices(): PurchaseInvoicesContract
     {
-        return new PurchaseInvoices($this->transporter);
+        return $this->client->purchaseInvoices();
     }
 
     public function salesArticles(): SalesArticlesContract
     {
-        return new SalesArticles($this->transporter);
+        return $this->client->salesArticles();
     }
 
     public function salesInvoices(): SalesInvoicesContract
     {
-        return new SalesInvoices($this->transporter);
+        return $this->client->salesInvoices();
     }
 
     public function templates(): TemplatesContract
     {
-        return new Templates($this->transporter);
+        return $this->client->templates();
     }
 
     public function transactions(): TransactionsContract
     {
-        return new Transactions($this->transporter);
+        return $this->client->transactions();
     }
 }

--- a/src/Testing/Exceptions/NoFakeResponsesException.php
+++ b/src/Testing/Exceptions/NoFakeResponsesException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Testing\Exceptions;
+
+use RuntimeException;
+
+final class NoFakeResponsesException extends RuntimeException
+{
+    public function __construct()
+    {
+        parent::__construct('No fake responses left.');
+    }
+}

--- a/src/Testing/Responses/Concerns/Fakeable.php
+++ b/src/Testing/Responses/Concerns/Fakeable.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace EFinancialsClient\Testing\Responses\Concerns;
 
+use RuntimeException;
+
 trait Fakeable
 {
     /**
@@ -16,6 +18,14 @@ trait Fakeable
             'EFinancialsClient\\Testing\\Responses\\Fixtures\\',
             static::class
         ).'Fixture';
+
+        if (! class_exists($class)) {
+            throw new RuntimeException("Missing fixture class [{$class}] for response [".static::class.'].');
+        }
+
+        if (! defined("{$class}::ATTRIBUTES")) {
+            throw new RuntimeException("Fixture [{$class}] must define an ATTRIBUTES constant.");
+        }
 
         /** @var array<array-key, mixed> $attributes */
         $attributes = array_replace_recursive($class::ATTRIBUTES, $override);

--- a/src/Testing/TransporterFake.php
+++ b/src/Testing/TransporterFake.php
@@ -6,9 +6,10 @@ namespace EFinancialsClient\Testing;
 
 use EFinancialsClient\Contracts\ResponseContract;
 use EFinancialsClient\Contracts\TransporterContract;
+use EFinancialsClient\Testing\Exceptions\NoFakeResponsesException;
 use EFinancialsClient\ValueObjects\Transporter\Payload;
 use EFinancialsClient\ValueObjects\Transporter\Response;
-use Exception;
+use JsonException;
 use Throwable;
 
 /**
@@ -20,6 +21,11 @@ final class TransporterFake implements TransporterContract
      * @var array<int, Payload>
      */
     private array $recorded = [];
+
+    /**
+     * @var array<int, array{0: Payload, 1: Response}>
+     */
+    private array $recordedPairs = [];
 
     /**
      * @param  array<int, ResponseContract|array<array-key, mixed>|string|Throwable>  $responses
@@ -43,7 +49,19 @@ final class TransporterFake implements TransporterContract
     }
 
     /**
+     * @return array<int, array{0: Payload, 1: Response}>
+     */
+    public function recordedPairs(): array
+    {
+        return $this->recordedPairs;
+    }
+
+    /**
      * {@inheritDoc}
+     *
+     * @throws NoFakeResponsesException
+     * @throws JsonException
+     * @throws Throwable
      */
     public function request(Payload $payload): Response
     {
@@ -52,13 +70,26 @@ final class TransporterFake implements TransporterContract
         $response = array_shift($this->responses);
 
         if ($response === null) {
-            throw new Exception('No fake responses left.');
+            throw new NoFakeResponsesException;
         }
 
         if ($response instanceof Throwable) {
             throw $response;
         }
 
+        $resolved = $this->resolve($response);
+        $this->recordedPairs[] = [$payload, $resolved];
+
+        return $resolved;
+    }
+
+    /**
+     * @param  ResponseContract|array<array-key, mixed>|string  $response
+     *
+     * @throws JsonException
+     */
+    private function resolve(ResponseContract|array|string $response): Response
+    {
         if ($response instanceof ResponseContract) {
             return Response::from($response->toArray());
         }

--- a/tests/Fixtures/Responses/MissingFixtureResponse.php
+++ b/tests/Fixtures/Responses/MissingFixtureResponse.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Responses;
+
+use EFinancialsClient\Contracts\ResponseContract;
+use EFinancialsClient\Responses\Concerns\ArrayAccessible;
+use EFinancialsClient\Testing\Responses\Concerns\Fakeable;
+
+/**
+ * @implements ResponseContract<array{ok: bool}>
+ */
+final class MissingFixtureResponse implements ResponseContract
+{
+    /**
+     * @use ArrayAccessible<array{ok: bool}>
+     */
+    use ArrayAccessible;
+
+    use Fakeable;
+
+    private function __construct(public readonly bool $ok) {}
+
+    /**
+     * @param  array{ok?: bool}  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self((bool) ($attributes['ok'] ?? false));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toArray(): array
+    {
+        return ['ok' => $this->ok];
+    }
+}

--- a/tests/Testing/ClientFake.php
+++ b/tests/Testing/ClientFake.php
@@ -1,0 +1,110 @@
+<?php
+
+use EFinancialsClient\Enums\Transporter\Method;
+use EFinancialsClient\Exceptions\ErrorException;
+use EFinancialsClient\Responses\ApiResponse;
+use EFinancialsClient\Responses\Currencies\ListResponse as CurrenciesListResponse;
+use EFinancialsClient\Testing\ClientFake;
+use EFinancialsClient\Testing\Exceptions\NoFakeResponsesException;
+use EFinancialsClient\ValueObjects\Transporter\Payload;
+use GuzzleHttp\Psr7\Response as Psr7Response;
+use Tests\Fixtures\Responses\MissingFixtureResponse;
+
+covers(ClientFake::class);
+
+it('delegates resource accessors through the real client', function () {
+    $fake = new ClientFake([
+        CurrenciesListResponse::fake(),
+    ]);
+
+    $response = $fake->currencies()->all();
+
+    expect($response)->toBeInstanceOf(CurrenciesListResponse::class)
+        ->and($response->data[0]->id)->toBe('EUR')
+        ->and($fake->recorded())->toHaveCount(1);
+});
+
+it('matches assertSent against the exact resource path', function () {
+    $fake = new ClientFake([
+        ['ok' => true],
+        ['ok' => true],
+    ]);
+
+    $fake->journals()->get(1);
+    $fake->journals()->getFile(1);
+
+    $fake->assertSent('journals/1');
+    $fake->assertNotSent('journals');
+    $fake->assertSentTimes('journals/1', 1);
+    $fake->assertSent('journals/1/document_user');
+});
+
+it('counts exact resource sends with assertSent times', function () {
+    $fake = new ClientFake([
+        ApiResponse::fake(),
+        ApiResponse::fake(),
+        ApiResponse::fake(),
+    ]);
+
+    $fake->products()->deactivate(1);
+    $fake->products()->deactivate(1);
+    $fake->products()->reactivate(1);
+
+    $fake->assertSent('products/1/deactivate', 2);
+    $fake->assertSentTimes('products/1/reactivate', 1);
+    $fake->assertSent(
+        'products/1/deactivate',
+        fn (Payload $payload): bool => $payload->method() === Method::PATCH,
+    );
+});
+
+it('asserts when nothing was sent', function () {
+    $fake = new ClientFake;
+
+    $fake->assertNothingSent();
+    $fake->assertNotSent('currencies');
+});
+
+it('appends responses with addResponses', function () {
+    $fake = new ClientFake([
+        CurrenciesListResponse::fake(),
+    ]);
+
+    $fake->addResponses([
+        CurrenciesListResponse::from([
+            ['id' => 'USD', 'name_est' => 'USA dollar', 'name_eng' => 'US Dollar'],
+        ]),
+    ]);
+
+    expect($fake->currencies()->all()->data[0]->id)->toBe('EUR')
+        ->and($fake->currencies()->all()->data[0]->id)->toBe('USD');
+});
+
+it('accepts array and json string fake responses', function () {
+    $fake = new ClientFake([
+        ['current_page' => 1, 'total_pages' => 1, 'items' => []],
+        '{"current_page":1,"total_pages":1,"items":[]}',
+    ]);
+
+    expect($fake->products()->all()->items)->toBe([])
+        ->and($fake->products()->all()->items)->toBe([])
+        ->and($fake->recordedPairs())->toHaveCount(2);
+});
+
+it('rethrows queued throwables', function () {
+    $fake = new ClientFake([
+        new ErrorException('nope', new Psr7Response(500)),
+    ]);
+
+    $fake->journals()->all();
+})->throws(ErrorException::class, 'nope');
+
+it('throws a typed exception when the response queue is empty', function () {
+    $fake = new ClientFake;
+
+    $fake->currencies()->all();
+})->throws(NoFakeResponsesException::class, 'No fake responses left.');
+
+it('fails clearly when a response fixture class is missing', function () {
+    MissingFixtureResponse::fake();
+})->throws(RuntimeException::class, 'Missing fixture class');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

PR 5 from the post-#90 plan: redesign `ClientFake` so it stops duplicating every Client accessor and gets a stronger assertion/DX surface.

### Changes
1. **Composition** — `ClientFake` builds `new Client(TransporterFake)` and delegates resource accessors, so new resources only need Client/`ClientContract` updates.
2. **Exact-path `assertSent`** — matches the full resource path (no prefix matching); `clients` no longer matches `clients/1`.
3. **`assertSentTimes`** — also available as `assertSent($resource, $times)` (openai-php style).
4. **`recorded()` / `recordedPairs()`** — inspect sent payloads and successful `[Payload, Response]` pairs.
5. **`NoFakeResponsesException`** — typed empty-queue failure instead of a bare `Exception`.
6. **Fakeable hardening** — clear `RuntimeException` when the fixture class or `ATTRIBUTES` constant is missing.
7. **Tests** — dedicated `tests/Testing/ClientFake.php` coverage; README testing snippet updated.

### Breaking
- `assertSent('clients')` no longer matches nested paths like `clients/1` (assert the exact path instead).

### Out of scope
- Remaining Response DTOs (Invoices / Journals / Transactions / invoice families)
- Payload path helpers (PR10)

### Verification
- `composer test` green (lint, PHPStan, type coverage, Pest — 24 tests)

### What
- [ ] Bug Fix
- [x] New Feature

### Description
Redesign ClientFake to compose the real Client and improve assertion/fixture DX.

### Related
Follow-up to #96; deferred from #90

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc292-2ac0-79d0-9014-6126f82761ad?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc292-2ac0-79d0-9014-6126f82761ad&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

