### PR TITLE
feat: add Journals and Transactions response DTOs

### DIFF
--- a/src/Contracts/Resources/JournalsContract.php
+++ b/src/Contracts/Resources/JournalsContract.php
@@ -5,6 +5,10 @@ declare(strict_types=1);
 namespace EFinancialsClient\Contracts\Resources;
 
 use DateTime;
+use EFinancialsClient\Responses\ApiFileResponse;
+use EFinancialsClient\Responses\ApiResponse;
+use EFinancialsClient\Responses\Journals\JournalResponse;
+use EFinancialsClient\Responses\Journals\ListResponse;
 
 interface JournalsContract
 {
@@ -18,7 +22,7 @@ interface JournalsContract
      * @param  DateTime|string  $startDate  Effective date on given date or later.
      * @param  DateTime|string  $endDate  Effective date on given date or before.
      */
-    public function all(int $page = 1, DateTime|string $modifiedSince = '', DateTime|string $startDate = '', DateTime|string $endDate = ''): mixed;
+    public function all(int $page = 1, DateTime|string $modifiedSince = '', DateTime|string $startDate = '', DateTime|string $endDate = ''): ListResponse;
 
     /**
      * Retrieve one specific journal entry of the specified company.
@@ -27,23 +31,16 @@ interface JournalsContract
      *
      * @param  int  $id  Journal entry identificator.
      */
-    public function get(int $id): mixed;
+    public function get(int $id): JournalResponse;
 
     /**
      * Create a new journal entry of the specified company.
      *
      * @see https://rmp-api.rik.ee/api.html#operation/post-journals
      *
-     * @param array<string,mixed>|array{
-     *   "effective_date": "2014-05-31",
-     *   "postings": array,
-     *   "title": string,
-     *   "clients_id": int,
-     *   "cl_currencies_id": "EUR",
-     *   "document_number": string,
-     * } $parameters
+     * @param  array<string, mixed>  $parameters
      */
-    public function create(array $parameters = []): mixed;
+    public function create(array $parameters = []): ApiResponse;
 
     /**
      * Modify one specific journal entry of the specified company.
@@ -51,16 +48,9 @@ interface JournalsContract
      * @see https://rmp-api.rik.ee/api.html#operation/patch-journals_one
      *
      * @param  int  $id  Journal entry identificator.
-     * @param array<string,mixed>|array{
-     *   "effective_date": "2014-05-31",
-     *   "postings": array,
-     *   "title": string,
-     *   "clients_id": int,
-     *   "cl_currencies_id": "EUR",
-     *   "document_number": string,
-     * } $parameters
+     * @param  array<string, mixed>  $parameters
      */
-    public function update(int $id, array $parameters): mixed;
+    public function update(int $id, array $parameters): ApiResponse;
 
     /**
      * Delete one specific journal entry of the specified company.
@@ -69,7 +59,7 @@ interface JournalsContract
      *
      * @param  int  $id  Journal entry identificator.
      */
-    public function delete(int $id): mixed;
+    public function delete(int $id): ApiResponse;
 
     /**
      * Register one specific journal entry of the specified company.
@@ -78,7 +68,7 @@ interface JournalsContract
      *
      * @param  int  $id  Journal entry identificator.
      */
-    public function register(int $id): mixed;
+    public function register(int $id): ApiResponse;
 
     /**
      * Invalidate one specific journal entry of the specified company.
@@ -87,7 +77,7 @@ interface JournalsContract
      *
      * @param  int  $id  Journal entry identificator.
      */
-    public function invalidate(int $id): mixed;
+    public function invalidate(int $id): ApiResponse;
 
     /**
      * Retrieve the document related to a journal entry of the specified company.
@@ -96,7 +86,7 @@ interface JournalsContract
      *
      * @param  int  $id  Journal entry identificator.
      */
-    public function getFile(int $id): mixed;
+    public function getFile(int $id): ApiFileResponse;
 
     /**
      * Update the document related to a journal entry of the specified company.
@@ -104,12 +94,9 @@ interface JournalsContract
      * @see https://rmp-api.rik.ee/api.html#operation/put-journals_one_document_user
      *
      * @param  int  $id  Journal entry identificator.
-     * @param array<string,mixed>|array{
-     *   "name": string,
-     *   "contents": string,
-     * } $parameters Base64-encoded file payload.
+     * @param  array<string, mixed>  $parameters  Base64-encoded file payload.
      */
-    public function updateFile(int $id, array $parameters): mixed;
+    public function updateFile(int $id, array $parameters): ApiResponse;
 
     /**
      * Delete the document related to a journal entry of the specified company.
@@ -118,5 +105,5 @@ interface JournalsContract
      *
      * @param  int  $id  Journal entry identificator.
      */
-    public function deleteFile(int $id): mixed;
+    public function deleteFile(int $id): ApiResponse;
 }

--- a/src/Contracts/Resources/TransactionsContract.php
+++ b/src/Contracts/Resources/TransactionsContract.php
@@ -5,6 +5,10 @@ declare(strict_types=1);
 namespace EFinancialsClient\Contracts\Resources;
 
 use DateTime;
+use EFinancialsClient\Responses\ApiFileResponse;
+use EFinancialsClient\Responses\ApiResponse;
+use EFinancialsClient\Responses\Transactions\ListResponse;
+use EFinancialsClient\Responses\Transactions\TransactionResponse;
 
 interface TransactionsContract
 {
@@ -21,7 +25,7 @@ interface TransactionsContract
      * @param  string  $type  Object type.
      * @param  int|null  $clientsId  Customer identificator.
      */
-    public function all(int $page = 1, DateTime|string $modifiedSince = '', DateTime|string $startDate = '', DateTime|string $endDate = '', string $status = '', string $type = '', ?int $clientsId = null): mixed;
+    public function all(int $page = 1, DateTime|string $modifiedSince = '', DateTime|string $startDate = '', DateTime|string $endDate = '', string $status = '', string $type = '', ?int $clientsId = null): ListResponse;
 
     /**
      * Retrieve one specific transaction of the specified company.
@@ -30,24 +34,16 @@ interface TransactionsContract
      *
      * @param  int  $id  Transaction identificator.
      */
-    public function get(int $id): mixed;
+    public function get(int $id): TransactionResponse;
 
     /**
      * Create a new transaction of the specified company.
      *
      * @see https://rmp-api.rik.ee/api.html#operation/post-transactions
      *
-     * @param array<string,mixed>|array{
-     *   "accounts_dimensions_id": int,
-     *   "type": "D"|"C",
-     *   "amount": float,
-     *   "cl_currencies_id": "EUR",
-     *   "date": "2015-01-31",
-     *   "description": string,
-     *   "clients_id": int,
-     * } $parameters
+     * @param  array<string, mixed>  $parameters
      */
-    public function create(array $parameters = []): mixed;
+    public function create(array $parameters = []): ApiResponse;
 
     /**
      * Modify one specific transaction of the specified company.
@@ -55,17 +51,9 @@ interface TransactionsContract
      * @see https://rmp-api.rik.ee/api.html#operation/patch-transactions_one
      *
      * @param  int  $id  Transaction identificator.
-     * @param array<string,mixed>|array{
-     *   "accounts_dimensions_id": int,
-     *   "type": "D"|"C",
-     *   "amount": float,
-     *   "cl_currencies_id": "EUR",
-     *   "date": "2015-01-31",
-     *   "description": string,
-     *   "clients_id": int,
-     * } $parameters
+     * @param  array<string, mixed>  $parameters
      */
-    public function update(int $id, array $parameters): mixed;
+    public function update(int $id, array $parameters): ApiResponse;
 
     /**
      * Delete one specific transaction of the specified company.
@@ -74,7 +62,7 @@ interface TransactionsContract
      *
      * @param  int  $id  Transaction identificator.
      */
-    public function delete(int $id): mixed;
+    public function delete(int $id): ApiResponse;
 
     /**
      * Register one specific transaction of the specified company.
@@ -84,7 +72,7 @@ interface TransactionsContract
      * @param  int  $id  Transaction identificator.
      * @param  array<int, mixed>  $distributions  Optional transaction distribution rows.
      */
-    public function register(int $id, array $distributions = []): mixed;
+    public function register(int $id, array $distributions = []): ApiResponse;
 
     /**
      * Invalidate one specific transaction of the specified company.
@@ -93,7 +81,7 @@ interface TransactionsContract
      *
      * @param  int  $id  Transaction identificator.
      */
-    public function invalidate(int $id): mixed;
+    public function invalidate(int $id): ApiResponse;
 
     /**
      * Retrieve the document related to a transaction of the specified company.
@@ -102,7 +90,7 @@ interface TransactionsContract
      *
      * @param  int  $id  Transaction identificator.
      */
-    public function getFile(int $id): mixed;
+    public function getFile(int $id): ApiFileResponse;
 
     /**
      * Update the document related to a transaction of the specified company.
@@ -110,12 +98,9 @@ interface TransactionsContract
      * @see https://rmp-api.rik.ee/api.html#operation/put-transactions_one_document_user
      *
      * @param  int  $id  Transaction identificator.
-     * @param array<string,mixed>|array{
-     *   "name": string,
-     *   "contents": string,
-     * } $parameters Base64-encoded file payload.
+     * @param  array<string, mixed>  $parameters  Base64-encoded file payload.
      */
-    public function updateFile(int $id, array $parameters): mixed;
+    public function updateFile(int $id, array $parameters): ApiResponse;
 
     /**
      * Delete the document related to a transaction of the specified company.
@@ -124,5 +109,5 @@ interface TransactionsContract
      *
      * @param  int  $id  Transaction identificator.
      */
-    public function deleteFile(int $id): mixed;
+    public function deleteFile(int $id): ApiResponse;
 }

--- a/src/Resources/Journals.php
+++ b/src/Resources/Journals.php
@@ -5,9 +5,16 @@ declare(strict_types=1);
 namespace EFinancialsClient\Resources;
 
 use DateTime;
+use DateTimeInterface;
 use EFinancialsClient\Contracts\Resources\JournalsContract;
 use EFinancialsClient\Resources\Concerns\Transportable;
+use EFinancialsClient\Responses\ApiFileResponse;
+use EFinancialsClient\Responses\ApiResponse;
+use EFinancialsClient\Responses\Journals\JournalResponse;
+use EFinancialsClient\Responses\Journals\ListResponse;
 use EFinancialsClient\ValueObjects\Transporter\Payload;
+use EFinancialsClient\ValueObjects\Transporter\Response;
+use InvalidArgumentException;
 
 final class Journals implements JournalsContract
 {
@@ -28,7 +35,7 @@ final class Journals implements JournalsContract
         DateTime|string $modifiedSince = '',
         DateTime|string $startDate = '',
         DateTime|string $endDate = '',
-    ): mixed {
+    ): ListResponse {
         $query = [];
 
         if ($page !== 1) {
@@ -37,7 +44,7 @@ final class Journals implements JournalsContract
 
         if ($modifiedSince !== '') {
             $query['modified_since'] = ($modifiedSince instanceof DateTime)
-                ? $modifiedSince->format(\DateTimeInterface::ATOM)
+                ? $modifiedSince->format(DateTimeInterface::ATOM)
                 : $modifiedSince;
         }
 
@@ -54,9 +61,11 @@ final class Journals implements JournalsContract
         }
 
         $payload = Payload::get('journals', $query);
+
+        /** @var Response<array{current_page: int, total_pages: int, items: array<int, array<string, mixed>>}> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return ListResponse::from($response->data());
     }
 
     /**
@@ -66,12 +75,14 @@ final class Journals implements JournalsContract
      *
      * @param  int  $id  Journal entry identificator.
      */
-    public function get(int $id): mixed
+    public function get(int $id): JournalResponse
     {
         $payload = Payload::get('journals/'.$id);
+
+        /** @var Response<array<string, mixed>> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return JournalResponse::from($response->data());
     }
 
     /**
@@ -79,16 +90,9 @@ final class Journals implements JournalsContract
      *
      * @see https://rmp-api.rik.ee/api.html#operation/post-journals
      *
-     * @param array<string,mixed>|array{
-     *   "effective_date": "2014-05-31",
-     *   "postings": array,
-     *   "title": string,
-     *   "clients_id": int,
-     *   "cl_currencies_id": "EUR",
-     *   "document_number": string,
-     * } $parameters
+     * @param  array<string, mixed>  $parameters
      */
-    public function create(array $parameters = []): mixed
+    public function create(array $parameters = []): ApiResponse
     {
         $missingRequiredParameters = array_diff_key(
             array_flip(
@@ -103,15 +107,17 @@ final class Journals implements JournalsContract
         if (count($missingRequiredParameters) !== 0) {
             $missingKeys = implode(', ', array_keys($missingRequiredParameters));
 
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 "Missing required parameter(s): $missingKeys"
             );
         }
 
         $payload = Payload::post('journals', $parameters);
+
+        /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return ApiResponse::from($response->data());
     }
 
     /**
@@ -120,16 +126,9 @@ final class Journals implements JournalsContract
      * @see https://rmp-api.rik.ee/api.html#operation/patch-journals_one
      *
      * @param  int  $id  Journal entry identificator.
-     * @param array<string,mixed>|array{
-     *   "effective_date": "2014-05-31",
-     *   "postings": array,
-     *   "title": string,
-     *   "clients_id": int,
-     *   "cl_currencies_id": "EUR",
-     *   "document_number": string,
-     * } $parameters
+     * @param  array<string, mixed>  $parameters
      */
-    public function update(int $id, array $parameters): mixed
+    public function update(int $id, array $parameters): ApiResponse
     {
         $missingRequiredParameters = array_diff_key(
             array_flip(
@@ -144,15 +143,17 @@ final class Journals implements JournalsContract
         if (count($missingRequiredParameters) !== 0) {
             $missingKeys = implode(', ', array_keys($missingRequiredParameters));
 
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 "Missing required parameter(s): $missingKeys"
             );
         }
 
         $payload = Payload::patch('journals/'.$id, $parameters);
+
+        /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return ApiResponse::from($response->data());
     }
 
     /**
@@ -162,12 +163,14 @@ final class Journals implements JournalsContract
      *
      * @param  int  $id  Journal entry identificator.
      */
-    public function delete(int $id): mixed
+    public function delete(int $id): ApiResponse
     {
         $payload = Payload::delete('journals/'.$id);
+
+        /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return ApiResponse::from($response->data());
     }
 
     /**
@@ -177,12 +180,14 @@ final class Journals implements JournalsContract
      *
      * @param  int  $id  Journal entry identificator.
      */
-    public function register(int $id): mixed
+    public function register(int $id): ApiResponse
     {
         $payload = Payload::patch('journals/'.$id.'/register');
+
+        /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return ApiResponse::from($response->data());
     }
 
     /**
@@ -192,12 +197,14 @@ final class Journals implements JournalsContract
      *
      * @param  int  $id  Journal entry identificator.
      */
-    public function invalidate(int $id): mixed
+    public function invalidate(int $id): ApiResponse
     {
         $payload = Payload::patch('journals/'.$id.'/invalidate');
+
+        /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return ApiResponse::from($response->data());
     }
 
     /**
@@ -207,12 +214,14 @@ final class Journals implements JournalsContract
      *
      * @param  int  $id  Journal entry identificator.
      */
-    public function getFile(int $id): mixed
+    public function getFile(int $id): ApiFileResponse
     {
         $payload = Payload::get('journals/'.$id.'/document_user');
+
+        /** @var Response<array{name: string, contents: string}> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return ApiFileResponse::from($response->data());
     }
 
     /**
@@ -221,12 +230,9 @@ final class Journals implements JournalsContract
      * @see https://rmp-api.rik.ee/api.html#operation/put-journals_one_document_user
      *
      * @param  int  $id  Journal entry identificator.
-     * @param array<string,mixed>|array{
-     *   "name": string,
-     *   "contents": string,
-     * } $parameters Base64-encoded file payload.
+     * @param  array<string, mixed>  $parameters  Base64-encoded file payload.
      */
-    public function updateFile(int $id, array $parameters): mixed
+    public function updateFile(int $id, array $parameters): ApiResponse
     {
         $missingRequiredParameters = array_diff_key(
             array_flip(
@@ -241,15 +247,17 @@ final class Journals implements JournalsContract
         if (count($missingRequiredParameters) !== 0) {
             $missingKeys = implode(', ', array_keys($missingRequiredParameters));
 
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 "Missing required parameter(s): $missingKeys"
             );
         }
 
-        $payload = Payload::put('journals/'.$id.'/document_user');
+        $payload = Payload::put('journals/'.$id.'/document_user', $parameters);
+
+        /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return ApiResponse::from($response->data());
     }
 
     /**
@@ -259,11 +267,13 @@ final class Journals implements JournalsContract
      *
      * @param  int  $id  Journal entry identificator.
      */
-    public function deleteFile(int $id): mixed
+    public function deleteFile(int $id): ApiResponse
     {
         $payload = Payload::delete('journals/'.$id.'/document_user');
+
+        /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return ApiResponse::from($response->data());
     }
 }

--- a/src/Resources/Transactions.php
+++ b/src/Resources/Transactions.php
@@ -5,9 +5,16 @@ declare(strict_types=1);
 namespace EFinancialsClient\Resources;
 
 use DateTime;
+use DateTimeInterface;
 use EFinancialsClient\Contracts\Resources\TransactionsContract;
 use EFinancialsClient\Resources\Concerns\Transportable;
+use EFinancialsClient\Responses\ApiFileResponse;
+use EFinancialsClient\Responses\ApiResponse;
+use EFinancialsClient\Responses\Transactions\ListResponse;
+use EFinancialsClient\Responses\Transactions\TransactionResponse;
 use EFinancialsClient\ValueObjects\Transporter\Payload;
+use EFinancialsClient\ValueObjects\Transporter\Response;
+use InvalidArgumentException;
 
 final class Transactions implements TransactionsContract
 {
@@ -34,7 +41,7 @@ final class Transactions implements TransactionsContract
         string $status = '',
         string $type = '',
         ?int $clientsId = null,
-    ): mixed {
+    ): ListResponse {
         $query = [];
 
         if ($page !== 1) {
@@ -43,7 +50,7 @@ final class Transactions implements TransactionsContract
 
         if ($modifiedSince !== '') {
             $query['modified_since'] = ($modifiedSince instanceof DateTime)
-                ? $modifiedSince->format(\DateTimeInterface::ATOM)
+                ? $modifiedSince->format(DateTimeInterface::ATOM)
                 : $modifiedSince;
         }
 
@@ -72,9 +79,11 @@ final class Transactions implements TransactionsContract
         }
 
         $payload = Payload::get('transactions', $query);
+
+        /** @var Response<array{current_page: int, total_pages: int, items: array<int, array<string, mixed>>}> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return ListResponse::from($response->data());
     }
 
     /**
@@ -84,12 +93,14 @@ final class Transactions implements TransactionsContract
      *
      * @param  int  $id  Transaction identificator.
      */
-    public function get(int $id): mixed
+    public function get(int $id): TransactionResponse
     {
         $payload = Payload::get('transactions/'.$id);
+
+        /** @var Response<array<string, mixed>> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return TransactionResponse::from($response->data());
     }
 
     /**
@@ -97,17 +108,9 @@ final class Transactions implements TransactionsContract
      *
      * @see https://rmp-api.rik.ee/api.html#operation/post-transactions
      *
-     * @param array<string,mixed>|array{
-     *   "accounts_dimensions_id": int,
-     *   "type": "D"|"C",
-     *   "amount": float,
-     *   "cl_currencies_id": "EUR",
-     *   "date": "2015-01-31",
-     *   "description": string,
-     *   "clients_id": int,
-     * } $parameters
+     * @param  array<string, mixed>  $parameters
      */
-    public function create(array $parameters = []): mixed
+    public function create(array $parameters = []): ApiResponse
     {
         $missingRequiredParameters = array_diff_key(
             array_flip(
@@ -125,15 +128,17 @@ final class Transactions implements TransactionsContract
         if (count($missingRequiredParameters) !== 0) {
             $missingKeys = implode(', ', array_keys($missingRequiredParameters));
 
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 "Missing required parameter(s): $missingKeys"
             );
         }
 
         $payload = Payload::post('transactions', $parameters);
+
+        /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return ApiResponse::from($response->data());
     }
 
     /**
@@ -142,17 +147,9 @@ final class Transactions implements TransactionsContract
      * @see https://rmp-api.rik.ee/api.html#operation/patch-transactions_one
      *
      * @param  int  $id  Transaction identificator.
-     * @param array<string,mixed>|array{
-     *   "accounts_dimensions_id": int,
-     *   "type": "D"|"C",
-     *   "amount": float,
-     *   "cl_currencies_id": "EUR",
-     *   "date": "2015-01-31",
-     *   "description": string,
-     *   "clients_id": int,
-     * } $parameters
+     * @param  array<string, mixed>  $parameters
      */
-    public function update(int $id, array $parameters): mixed
+    public function update(int $id, array $parameters): ApiResponse
     {
         $missingRequiredParameters = array_diff_key(
             array_flip(
@@ -170,15 +167,17 @@ final class Transactions implements TransactionsContract
         if (count($missingRequiredParameters) !== 0) {
             $missingKeys = implode(', ', array_keys($missingRequiredParameters));
 
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 "Missing required parameter(s): $missingKeys"
             );
         }
 
         $payload = Payload::patch('transactions/'.$id, $parameters);
+
+        /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return ApiResponse::from($response->data());
     }
 
     /**
@@ -188,12 +187,14 @@ final class Transactions implements TransactionsContract
      *
      * @param  int  $id  Transaction identificator.
      */
-    public function delete(int $id): mixed
+    public function delete(int $id): ApiResponse
     {
         $payload = Payload::delete('transactions/'.$id);
+
+        /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return ApiResponse::from($response->data());
     }
 
     /**
@@ -204,12 +205,14 @@ final class Transactions implements TransactionsContract
      * @param  int  $id  Transaction identificator.
      * @param  array<int, mixed>  $distributions  Optional transaction distribution rows.
      */
-    public function register(int $id, array $distributions = []): mixed
+    public function register(int $id, array $distributions = []): ApiResponse
     {
         $payload = Payload::patch('transactions/'.$id.'/register', $distributions);
+
+        /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return ApiResponse::from($response->data());
     }
 
     /**
@@ -219,12 +222,14 @@ final class Transactions implements TransactionsContract
      *
      * @param  int  $id  Transaction identificator.
      */
-    public function invalidate(int $id): mixed
+    public function invalidate(int $id): ApiResponse
     {
         $payload = Payload::patch('transactions/'.$id.'/invalidate');
+
+        /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return ApiResponse::from($response->data());
     }
 
     /**
@@ -234,12 +239,14 @@ final class Transactions implements TransactionsContract
      *
      * @param  int  $id  Transaction identificator.
      */
-    public function getFile(int $id): mixed
+    public function getFile(int $id): ApiFileResponse
     {
         $payload = Payload::get('transactions/'.$id.'/document_user');
+
+        /** @var Response<array{name: string, contents: string}> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return ApiFileResponse::from($response->data());
     }
 
     /**
@@ -248,12 +255,9 @@ final class Transactions implements TransactionsContract
      * @see https://rmp-api.rik.ee/api.html#operation/put-transactions_one_document_user
      *
      * @param  int  $id  Transaction identificator.
-     * @param array<string,mixed>|array{
-     *   "name": string,
-     *   "contents": string,
-     * } $parameters Base64-encoded file payload.
+     * @param  array<string, mixed>  $parameters  Base64-encoded file payload.
      */
-    public function updateFile(int $id, array $parameters): mixed
+    public function updateFile(int $id, array $parameters): ApiResponse
     {
         $missingRequiredParameters = array_diff_key(
             array_flip(
@@ -268,15 +272,17 @@ final class Transactions implements TransactionsContract
         if (count($missingRequiredParameters) !== 0) {
             $missingKeys = implode(', ', array_keys($missingRequiredParameters));
 
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 "Missing required parameter(s): $missingKeys"
             );
         }
 
-        $payload = Payload::put('transactions/'.$id.'/document_user');
+        $payload = Payload::put('transactions/'.$id.'/document_user', $parameters);
+
+        /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return ApiResponse::from($response->data());
     }
 
     /**
@@ -286,11 +292,13 @@ final class Transactions implements TransactionsContract
      *
      * @param  int  $id  Transaction identificator.
      */
-    public function deleteFile(int $id): mixed
+    public function deleteFile(int $id): ApiResponse
     {
         $payload = Payload::delete('transactions/'.$id.'/document_user');
+
+        /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return ApiResponse::from($response->data());
     }
 }

--- a/src/Responses/Journals/JournalResponse.php
+++ b/src/Responses/Journals/JournalResponse.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Responses\Journals;
+
+use EFinancialsClient\Contracts\ResponseContract;
+use EFinancialsClient\Responses\Concerns\ArrayAccessible;
+use EFinancialsClient\Responses\Concerns\NormalizesAttributes;
+use EFinancialsClient\Testing\Responses\Concerns\Fakeable;
+
+/**
+ * Full projection of the OpenAPI `Journals` schema, plus example-backed fields
+ * (`insert_date`, `register_date`, `is_deleted`).
+ *
+ * @see https://rmp-api.rik.ee/api.html#operation/get-journals_one
+ *
+ * @phpstan-import-type PostingData from PostingResponse
+ *
+ * @phpstan-type JournalData array{
+ *     id: int|null,
+ *     parent_id: int|null,
+ *     clients_id: int|null,
+ *     subclients_id: int|null,
+ *     number: int|null,
+ *     amendment_number: int|null,
+ *     title: string|null,
+ *     effective_date: string|null,
+ *     registered: bool|null,
+ *     operations_id: int|null,
+ *     operation_type: string|null,
+ *     document_number: string|null,
+ *     cl_currencies_id: string|null,
+ *     currency_rate: float|null,
+ *     base_document_files_id: int|null,
+ *     is_xls_imported: bool|null,
+ *     postings: array<int, PostingData>,
+ *     insert_date: string|null,
+ *     register_date: string|null,
+ *     is_deleted: bool|null
+ * }
+ *
+ * @implements ResponseContract<JournalData>
+ */
+final class JournalResponse implements ResponseContract
+{
+    /**
+     * @use ArrayAccessible<JournalData>
+     */
+    use ArrayAccessible;
+
+    use Fakeable;
+    use NormalizesAttributes;
+
+    /**
+     * @param  array<int, PostingResponse>  $postings
+     */
+    private function __construct(
+        public readonly ?int $id,
+        public readonly ?int $parentId,
+        public readonly ?int $clientsId,
+        public readonly ?int $subclientsId,
+        public readonly ?int $number,
+        public readonly ?int $amendmentNumber,
+        public readonly ?string $title,
+        public readonly ?string $effectiveDate,
+        public readonly ?bool $registered,
+        public readonly ?int $operationsId,
+        public readonly ?string $operationType,
+        public readonly ?string $documentNumber,
+        public readonly ?string $clCurrenciesId,
+        public readonly ?float $currencyRate,
+        public readonly ?int $baseDocumentFilesId,
+        public readonly ?bool $isXlsImported,
+        public readonly array $postings,
+        public readonly ?string $insertDate,
+        public readonly ?string $registerDate,
+        public readonly ?bool $isDeleted,
+    ) {}
+
+    /**
+     * @param  array<array-key, mixed>  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        /** @var array<int, array<string, mixed>> $rawPostings */
+        $rawPostings = is_array($attributes['postings'] ?? null) ? $attributes['postings'] : [];
+
+        $postings = array_values(array_map(
+            static fn (array $posting): PostingResponse => PostingResponse::from($posting),
+            $rawPostings,
+        ));
+
+        return new self(
+            self::intOrNull($attributes['id'] ?? null),
+            self::intOrNull($attributes['parent_id'] ?? null),
+            self::intOrNull($attributes['clients_id'] ?? null),
+            self::intOrNull($attributes['subclients_id'] ?? null),
+            self::intOrNull($attributes['number'] ?? null),
+            self::intOrNull($attributes['amendment_number'] ?? null),
+            self::stringOrNull($attributes['title'] ?? null),
+            self::stringOrNull($attributes['effective_date'] ?? null),
+            self::boolOrNull($attributes['registered'] ?? null),
+            self::intOrNull($attributes['operations_id'] ?? null),
+            self::stringOrNull($attributes['operation_type'] ?? null),
+            self::stringOrNull($attributes['document_number'] ?? null),
+            self::stringOrNull($attributes['cl_currencies_id'] ?? null),
+            self::floatOrNull($attributes['currency_rate'] ?? null),
+            self::intOrNull($attributes['base_document_files_id'] ?? null),
+            self::boolOrNull($attributes['is_xls_imported'] ?? null),
+            $postings,
+            self::stringOrNull($attributes['insert_date'] ?? null),
+            self::stringOrNull($attributes['register_date'] ?? null),
+            self::boolOrNull($attributes['is_deleted'] ?? null),
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'parent_id' => $this->parentId,
+            'clients_id' => $this->clientsId,
+            'subclients_id' => $this->subclientsId,
+            'number' => $this->number,
+            'amendment_number' => $this->amendmentNumber,
+            'title' => $this->title,
+            'effective_date' => $this->effectiveDate,
+            'registered' => $this->registered,
+            'operations_id' => $this->operationsId,
+            'operation_type' => $this->operationType,
+            'document_number' => $this->documentNumber,
+            'cl_currencies_id' => $this->clCurrenciesId,
+            'currency_rate' => $this->currencyRate,
+            'base_document_files_id' => $this->baseDocumentFilesId,
+            'is_xls_imported' => $this->isXlsImported,
+            'postings' => array_map(
+                static fn (PostingResponse $posting): array => $posting->toArray(),
+                $this->postings,
+            ),
+            'insert_date' => $this->insertDate,
+            'register_date' => $this->registerDate,
+            'is_deleted' => $this->isDeleted,
+        ];
+    }
+}

--- a/src/Responses/Journals/ListResponse.php
+++ b/src/Responses/Journals/ListResponse.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Responses\Journals;
+
+use EFinancialsClient\Contracts\ResponseContract;
+use EFinancialsClient\Responses\Concerns\ArrayAccessible;
+use EFinancialsClient\Responses\Concerns\NormalizesAttributes;
+use EFinancialsClient\Testing\Responses\Concerns\Fakeable;
+
+/**
+ * @phpstan-import-type JournalData from JournalResponse
+ *
+ * @implements ResponseContract<array{current_page: int, total_pages: int, items: array<int, JournalData>}>
+ */
+final class ListResponse implements ResponseContract
+{
+    /**
+     * @use ArrayAccessible<array{current_page: int, total_pages: int, items: array<int, JournalData>}>
+     */
+    use ArrayAccessible;
+
+    use Fakeable;
+    use NormalizesAttributes;
+
+    /**
+     * @param  array<int, JournalResponse>  $items
+     */
+    private function __construct(
+        public readonly int $currentPage,
+        public readonly int $totalPages,
+        public readonly array $items,
+    ) {}
+
+    /**
+     * @param  array<array-key, mixed>  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        /** @var array<int, array<string, mixed>> $rawItems */
+        $rawItems = is_array($attributes['items'] ?? null) ? $attributes['items'] : [];
+
+        $items = array_map(
+            static fn (array $item): JournalResponse => JournalResponse::from($item),
+            $rawItems,
+        );
+
+        return new self(
+            self::intValue($attributes['current_page'] ?? 0),
+            self::intValue($attributes['total_pages'] ?? 0),
+            $items,
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toArray(): array
+    {
+        return [
+            'current_page' => $this->currentPage,
+            'total_pages' => $this->totalPages,
+            'items' => array_map(
+                static fn (JournalResponse $journal): array => $journal->toArray(),
+                $this->items,
+            ),
+        ];
+    }
+}

--- a/src/Responses/Journals/PostingResponse.php
+++ b/src/Responses/Journals/PostingResponse.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Responses\Journals;
+
+use EFinancialsClient\Contracts\ResponseContract;
+use EFinancialsClient\Responses\Concerns\ArrayAccessible;
+use EFinancialsClient\Responses\Concerns\NormalizesAttributes;
+use EFinancialsClient\Testing\Responses\Concerns\Fakeable;
+
+/**
+ * Full projection of the OpenAPI `Postings` schema, plus example-backed `is_deleted`.
+ *
+ * @see https://rmp-api.rik.ee/openapi.yaml
+ *
+ * @phpstan-type PostingData array{
+ *     id: int|null,
+ *     journals_id: int|null,
+ *     accounts_id: int|null,
+ *     accounts_dimensions_id: int|null,
+ *     type: string|null,
+ *     amount: float|null,
+ *     base_amount: float|null,
+ *     cl_currencies_id: string|null,
+ *     projects_project_id: int|null,
+ *     projects_location_id: int|null,
+ *     projects_person_id: int|null,
+ *     is_deleted: bool|null
+ * }
+ *
+ * @implements ResponseContract<PostingData>
+ */
+final class PostingResponse implements ResponseContract
+{
+    /**
+     * @use ArrayAccessible<PostingData>
+     */
+    use ArrayAccessible;
+
+    use Fakeable;
+    use NormalizesAttributes;
+
+    private function __construct(
+        public readonly ?int $id,
+        public readonly ?int $journalsId,
+        public readonly ?int $accountsId,
+        public readonly ?int $accountsDimensionsId,
+        public readonly ?string $type,
+        public readonly ?float $amount,
+        public readonly ?float $baseAmount,
+        public readonly ?string $clCurrenciesId,
+        public readonly ?int $projectsProjectId,
+        public readonly ?int $projectsLocationId,
+        public readonly ?int $projectsPersonId,
+        public readonly ?bool $isDeleted,
+    ) {}
+
+    /**
+     * @param  array<array-key, mixed>  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            self::intOrNull($attributes['id'] ?? null),
+            self::intOrNull($attributes['journals_id'] ?? null),
+            self::intOrNull($attributes['accounts_id'] ?? null),
+            self::intOrNull($attributes['accounts_dimensions_id'] ?? null),
+            self::stringOrNull($attributes['type'] ?? null),
+            self::floatOrNull($attributes['amount'] ?? null),
+            self::floatOrNull($attributes['base_amount'] ?? null),
+            self::stringOrNull($attributes['cl_currencies_id'] ?? null),
+            self::intOrNull($attributes['projects_project_id'] ?? null),
+            self::intOrNull($attributes['projects_location_id'] ?? null),
+            self::intOrNull($attributes['projects_person_id'] ?? null),
+            self::boolOrNull($attributes['is_deleted'] ?? null),
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'journals_id' => $this->journalsId,
+            'accounts_id' => $this->accountsId,
+            'accounts_dimensions_id' => $this->accountsDimensionsId,
+            'type' => $this->type,
+            'amount' => $this->amount,
+            'base_amount' => $this->baseAmount,
+            'cl_currencies_id' => $this->clCurrenciesId,
+            'projects_project_id' => $this->projectsProjectId,
+            'projects_location_id' => $this->projectsLocationId,
+            'projects_person_id' => $this->projectsPersonId,
+            'is_deleted' => $this->isDeleted,
+        ];
+    }
+}

--- a/src/Responses/Transactions/ListResponse.php
+++ b/src/Responses/Transactions/ListResponse.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Responses\Transactions;
+
+use EFinancialsClient\Contracts\ResponseContract;
+use EFinancialsClient\Responses\Concerns\ArrayAccessible;
+use EFinancialsClient\Responses\Concerns\NormalizesAttributes;
+use EFinancialsClient\Testing\Responses\Concerns\Fakeable;
+
+/**
+ * @phpstan-import-type TransactionData from TransactionResponse
+ *
+ * @implements ResponseContract<array{current_page: int, total_pages: int, items: array<int, TransactionData>}>
+ */
+final class ListResponse implements ResponseContract
+{
+    /**
+     * @use ArrayAccessible<array{current_page: int, total_pages: int, items: array<int, TransactionData>}>
+     */
+    use ArrayAccessible;
+
+    use Fakeable;
+    use NormalizesAttributes;
+
+    /**
+     * @param  array<int, TransactionResponse>  $items
+     */
+    private function __construct(
+        public readonly int $currentPage,
+        public readonly int $totalPages,
+        public readonly array $items,
+    ) {}
+
+    /**
+     * @param  array<array-key, mixed>  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        /** @var array<int, array<string, mixed>> $rawItems */
+        $rawItems = is_array($attributes['items'] ?? null) ? $attributes['items'] : [];
+
+        $items = array_map(
+            static fn (array $item): TransactionResponse => TransactionResponse::from($item),
+            $rawItems,
+        );
+
+        return new self(
+            self::intValue($attributes['current_page'] ?? 0),
+            self::intValue($attributes['total_pages'] ?? 0),
+            $items,
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toArray(): array
+    {
+        return [
+            'current_page' => $this->currentPage,
+            'total_pages' => $this->totalPages,
+            'items' => array_map(
+                static fn (TransactionResponse $transaction): array => $transaction->toArray(),
+                $this->items,
+            ),
+        ];
+    }
+}

--- a/src/Responses/Transactions/TransactionItemResponse.php
+++ b/src/Responses/Transactions/TransactionItemResponse.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Responses\Transactions;
+
+use EFinancialsClient\Contracts\ResponseContract;
+use EFinancialsClient\Responses\Concerns\ArrayAccessible;
+use EFinancialsClient\Responses\Concerns\NormalizesAttributes;
+use EFinancialsClient\Testing\Responses\Concerns\Fakeable;
+
+/**
+ * Full projection of the OpenAPI `TransactionsItems` schema.
+ *
+ * @see https://rmp-api.rik.ee/openapi.yaml
+ *
+ * @phpstan-type TransactionItemData array{
+ *     id: int|null,
+ *     accounts_id: int|null,
+ *     accounts_dimensions_id: int|null,
+ *     relation_table: string|null,
+ *     relation_id: int|null,
+ *     amount: float|null,
+ *     base_amount: float|null,
+ *     currency_rate: float|null,
+ *     cl_currencies_id: string|null
+ * }
+ *
+ * @implements ResponseContract<TransactionItemData>
+ */
+final class TransactionItemResponse implements ResponseContract
+{
+    /**
+     * @use ArrayAccessible<TransactionItemData>
+     */
+    use ArrayAccessible;
+
+    use Fakeable;
+    use NormalizesAttributes;
+
+    private function __construct(
+        public readonly ?int $id,
+        public readonly ?int $accountsId,
+        public readonly ?int $accountsDimensionsId,
+        public readonly ?string $relationTable,
+        public readonly ?int $relationId,
+        public readonly ?float $amount,
+        public readonly ?float $baseAmount,
+        public readonly ?float $currencyRate,
+        public readonly ?string $clCurrenciesId,
+    ) {}
+
+    /**
+     * @param  array<array-key, mixed>  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            self::intOrNull($attributes['id'] ?? null),
+            self::intOrNull($attributes['accounts_id'] ?? null),
+            self::intOrNull($attributes['accounts_dimensions_id'] ?? null),
+            self::stringOrNull($attributes['relation_table'] ?? null),
+            self::intOrNull($attributes['relation_id'] ?? null),
+            self::floatOrNull($attributes['amount'] ?? null),
+            self::floatOrNull($attributes['base_amount'] ?? null),
+            self::floatOrNull($attributes['currency_rate'] ?? null),
+            self::stringOrNull($attributes['cl_currencies_id'] ?? null),
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'accounts_id' => $this->accountsId,
+            'accounts_dimensions_id' => $this->accountsDimensionsId,
+            'relation_table' => $this->relationTable,
+            'relation_id' => $this->relationId,
+            'amount' => $this->amount,
+            'base_amount' => $this->baseAmount,
+            'currency_rate' => $this->currencyRate,
+            'cl_currencies_id' => $this->clCurrenciesId,
+        ];
+    }
+}

--- a/src/Responses/Transactions/TransactionResponse.php
+++ b/src/Responses/Transactions/TransactionResponse.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Responses\Transactions;
+
+use EFinancialsClient\Contracts\ResponseContract;
+use EFinancialsClient\Responses\Concerns\ArrayAccessible;
+use EFinancialsClient\Responses\Concerns\NormalizesAttributes;
+use EFinancialsClient\Testing\Responses\Concerns\Fakeable;
+
+/**
+ * Full projection of the OpenAPI `Transactions` schema, plus example-backed fields
+ * (`is_deleted`, `operation_type`).
+ *
+ * @see https://rmp-api.rik.ee/api.html#operation/get-transactions_one
+ *
+ * @phpstan-import-type TransactionItemData from TransactionItemResponse
+ *
+ * @phpstan-type TransactionData array{
+ *     id: int|null,
+ *     uploaded_files_id: int|null,
+ *     accounts_id: int|null,
+ *     accounts_dimensions_id: int|null,
+ *     status: string|null,
+ *     bank_accounts_id: int|null,
+ *     bank_ref_number: string|null,
+ *     bank_subtype: string|null,
+ *     type: string|null,
+ *     clients_id: int|null,
+ *     bank_code: string|null,
+ *     bank_account_no: string|null,
+ *     bank_account_name: string|null,
+ *     ref_number: string|null,
+ *     amount: float|null,
+ *     base_amount: float|null,
+ *     currency_rate: float|null,
+ *     cl_currencies_id: string|null,
+ *     description: string|null,
+ *     date: string|null,
+ *     transactions_files_id: int|null,
+ *     export_format: string|null,
+ *     items: array<int, TransactionItemData>,
+ *     is_deleted: bool|null,
+ *     operation_type: string|null
+ * }
+ *
+ * @implements ResponseContract<TransactionData>
+ */
+final class TransactionResponse implements ResponseContract
+{
+    /**
+     * @use ArrayAccessible<TransactionData>
+     */
+    use ArrayAccessible;
+
+    use Fakeable;
+    use NormalizesAttributes;
+
+    /**
+     * @param  array<int, TransactionItemResponse>  $items
+     */
+    private function __construct(
+        public readonly ?int $id,
+        public readonly ?int $uploadedFilesId,
+        public readonly ?int $accountsId,
+        public readonly ?int $accountsDimensionsId,
+        public readonly ?string $status,
+        public readonly ?int $bankAccountsId,
+        public readonly ?string $bankRefNumber,
+        public readonly ?string $bankSubtype,
+        public readonly ?string $type,
+        public readonly ?int $clientsId,
+        public readonly ?string $bankCode,
+        public readonly ?string $bankAccountNo,
+        public readonly ?string $bankAccountName,
+        public readonly ?string $refNumber,
+        public readonly ?float $amount,
+        public readonly ?float $baseAmount,
+        public readonly ?float $currencyRate,
+        public readonly ?string $clCurrenciesId,
+        public readonly ?string $description,
+        public readonly ?string $date,
+        public readonly ?int $transactionsFilesId,
+        public readonly ?string $exportFormat,
+        public readonly array $items,
+        public readonly ?bool $isDeleted,
+        public readonly ?string $operationType,
+    ) {}
+
+    /**
+     * @param  array<array-key, mixed>  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        /** @var array<int, array<string, mixed>> $rawItems */
+        $rawItems = is_array($attributes['items'] ?? null) ? $attributes['items'] : [];
+
+        $items = array_values(array_map(
+            static fn (array $item): TransactionItemResponse => TransactionItemResponse::from($item),
+            $rawItems,
+        ));
+
+        return new self(
+            self::intOrNull($attributes['id'] ?? null),
+            self::intOrNull($attributes['uploaded_files_id'] ?? null),
+            self::intOrNull($attributes['accounts_id'] ?? null),
+            self::intOrNull($attributes['accounts_dimensions_id'] ?? null),
+            self::stringOrNull($attributes['status'] ?? null),
+            self::intOrNull($attributes['bank_accounts_id'] ?? null),
+            self::stringOrNull($attributes['bank_ref_number'] ?? null),
+            self::stringOrNull($attributes['bank_subtype'] ?? null),
+            self::stringOrNull($attributes['type'] ?? null),
+            self::intOrNull($attributes['clients_id'] ?? null),
+            self::stringOrNull($attributes['bank_code'] ?? null),
+            self::stringOrNull($attributes['bank_account_no'] ?? null),
+            self::stringOrNull($attributes['bank_account_name'] ?? null),
+            self::stringOrNull($attributes['ref_number'] ?? null),
+            self::floatOrNull($attributes['amount'] ?? null),
+            self::floatOrNull($attributes['base_amount'] ?? null),
+            self::floatOrNull($attributes['currency_rate'] ?? null),
+            self::stringOrNull($attributes['cl_currencies_id'] ?? null),
+            self::stringOrNull($attributes['description'] ?? null),
+            self::stringOrNull($attributes['date'] ?? null),
+            self::intOrNull($attributes['transactions_files_id'] ?? null),
+            self::stringOrNull($attributes['export_format'] ?? null),
+            $items,
+            self::boolOrNull($attributes['is_deleted'] ?? null),
+            self::stringOrNull($attributes['operation_type'] ?? null),
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'uploaded_files_id' => $this->uploadedFilesId,
+            'accounts_id' => $this->accountsId,
+            'accounts_dimensions_id' => $this->accountsDimensionsId,
+            'status' => $this->status,
+            'bank_accounts_id' => $this->bankAccountsId,
+            'bank_ref_number' => $this->bankRefNumber,
+            'bank_subtype' => $this->bankSubtype,
+            'type' => $this->type,
+            'clients_id' => $this->clientsId,
+            'bank_code' => $this->bankCode,
+            'bank_account_no' => $this->bankAccountNo,
+            'bank_account_name' => $this->bankAccountName,
+            'ref_number' => $this->refNumber,
+            'amount' => $this->amount,
+            'base_amount' => $this->baseAmount,
+            'currency_rate' => $this->currencyRate,
+            'cl_currencies_id' => $this->clCurrenciesId,
+            'description' => $this->description,
+            'date' => $this->date,
+            'transactions_files_id' => $this->transactionsFilesId,
+            'export_format' => $this->exportFormat,
+            'items' => array_map(
+                static fn (TransactionItemResponse $item): array => $item->toArray(),
+                $this->items,
+            ),
+            'is_deleted' => $this->isDeleted,
+            'operation_type' => $this->operationType,
+        ];
+    }
+}

--- a/src/Testing/Responses/Fixtures/Journals/JournalResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/Journals/JournalResponseFixture.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Testing\Responses\Fixtures\Journals;
+
+/**
+ * OpenAPI `Journals` schema example (fuller projection).
+ *
+ * @see https://rmp-api.rik.ee/openapi.yaml
+ */
+final class JournalResponseFixture
+{
+    /**
+     * @var array<string, mixed>
+     */
+    public const ATTRIBUTES = [
+        'id' => 739,
+        'parent_id' => null,
+        'clients_id' => 172,
+        'subclients_id' => null,
+        'number' => 10008,
+        'amendment_number' => 0,
+        'title' => 'EMTA KMD alusel kanne nr 10008',
+        'effective_date' => '2014-05-31',
+        'registered' => true,
+        'operations_id' => 21,
+        'operation_type' => 'EMTA_VAT_DECLARATION',
+        'document_number' => 'EMTA KMD 31.05.2014',
+        'cl_currencies_id' => 'EUR',
+        'currency_rate' => 1.0,
+        'base_document_files_id' => null,
+        'is_xls_imported' => false,
+        'postings' => [
+            PostingResponseFixture::ATTRIBUTES,
+            [
+                'id' => 8204,
+                'journals_id' => null,
+                'accounts_id' => 2510,
+                'accounts_dimensions_id' => null,
+                'type' => 'C',
+                'amount' => 100.0,
+                'base_amount' => 100.0,
+                'cl_currencies_id' => 'EUR',
+                'projects_project_id' => null,
+                'projects_location_id' => null,
+                'projects_person_id' => null,
+                'is_deleted' => false,
+            ],
+        ],
+        'insert_date' => '2014-06-20',
+        'register_date' => '2014-10-29',
+        'is_deleted' => false,
+    ];
+}

--- a/src/Testing/Responses/Fixtures/Journals/ListResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/Journals/ListResponseFixture.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Testing\Responses\Fixtures\Journals;
+
+final class ListResponseFixture
+{
+    /**
+     * @var array{current_page: int, total_pages: int, items: array<int, array<string, mixed>>}
+     */
+    public const ATTRIBUTES = [
+        'current_page' => 1,
+        'total_pages' => 1,
+        'items' => [
+            JournalResponseFixture::ATTRIBUTES,
+        ],
+    ];
+}

--- a/src/Testing/Responses/Fixtures/Journals/PostingResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/Journals/PostingResponseFixture.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Testing\Responses\Fixtures\Journals;
+
+/**
+ * OpenAPI `Postings` schema example (fuller projection).
+ *
+ * @see https://rmp-api.rik.ee/openapi.yaml
+ */
+final class PostingResponseFixture
+{
+    /**
+     * @var array<string, mixed>
+     */
+    public const ATTRIBUTES = [
+        'id' => 8203,
+        'journals_id' => null,
+        'accounts_id' => 2511,
+        'accounts_dimensions_id' => null,
+        'type' => 'D',
+        'amount' => 100.0,
+        'base_amount' => 100.0,
+        'cl_currencies_id' => 'EUR',
+        'projects_project_id' => null,
+        'projects_location_id' => null,
+        'projects_person_id' => null,
+        'is_deleted' => false,
+    ];
+}

--- a/src/Testing/Responses/Fixtures/Transactions/ListResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/Transactions/ListResponseFixture.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Testing\Responses\Fixtures\Transactions;
+
+final class ListResponseFixture
+{
+    /**
+     * @var array{current_page: int, total_pages: int, items: array<int, array<string, mixed>>}
+     */
+    public const ATTRIBUTES = [
+        'current_page' => 1,
+        'total_pages' => 1,
+        'items' => [
+            TransactionResponseFixture::ATTRIBUTES,
+        ],
+    ];
+}

--- a/src/Testing/Responses/Fixtures/Transactions/TransactionItemResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/Transactions/TransactionItemResponseFixture.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Testing\Responses\Fixtures\Transactions;
+
+/**
+ * OpenAPI `TransactionsItems` schema projection.
+ *
+ * @see https://rmp-api.rik.ee/openapi.yaml
+ */
+final class TransactionItemResponseFixture
+{
+    /**
+     * @var array<string, mixed>
+     */
+    public const ATTRIBUTES = [
+        'id' => 1,
+        'accounts_id' => 1010,
+        'accounts_dimensions_id' => 4,
+        'relation_table' => null,
+        'relation_id' => null,
+        'amount' => 2348.32,
+        'base_amount' => 2348.32,
+        'currency_rate' => 1.0,
+        'cl_currencies_id' => 'EUR',
+    ];
+}

--- a/src/Testing/Responses/Fixtures/Transactions/TransactionResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/Transactions/TransactionResponseFixture.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Testing\Responses\Fixtures\Transactions;
+
+/**
+ * OpenAPI `Transactions` schema example (fuller projection).
+ *
+ * @see https://rmp-api.rik.ee/openapi.yaml
+ */
+final class TransactionResponseFixture
+{
+    /**
+     * @var array<string, mixed>
+     */
+    public const ATTRIBUTES = [
+        'id' => 2672,
+        'uploaded_files_id' => null,
+        'accounts_id' => 1010,
+        'accounts_dimensions_id' => 4,
+        'status' => 'CONFIRMED',
+        'bank_accounts_id' => null,
+        'bank_ref_number' => null,
+        'bank_subtype' => null,
+        'type' => 'D',
+        'clients_id' => 19,
+        'bank_code' => null,
+        'bank_account_no' => null,
+        'bank_account_name' => null,
+        'ref_number' => null,
+        'amount' => 2348.32,
+        'base_amount' => 2348.32,
+        'currency_rate' => 1.0,
+        'cl_currencies_id' => 'EUR',
+        'description' => 'Töötasu väljamakse nr 10069 (Bob Smith 01.2015) tasumine sularahas',
+        'date' => '2015-01-31',
+        'transactions_files_id' => null,
+        'export_format' => null,
+        'items' => [],
+        'is_deleted' => false,
+        'operation_type' => null,
+    ];
+}

--- a/tests/Client.php
+++ b/tests/Client.php
@@ -17,13 +17,20 @@ use EFinancialsClient\Responses\Clients\ClientResponse;
 use EFinancialsClient\Responses\Clients\ListResponse as ClientsListResponse;
 use EFinancialsClient\Responses\CostProfitCentres\ListResponse as CostProfitCentresListResponse;
 use EFinancialsClient\Responses\Currencies\ListResponse as CurrenciesListResponse;
+use EFinancialsClient\Responses\Journals\JournalResponse;
+use EFinancialsClient\Responses\Journals\ListResponse as JournalsListResponse;
+use EFinancialsClient\Responses\Journals\PostingResponse;
 use EFinancialsClient\Responses\Products\ListResponse as ProductsListResponse;
 use EFinancialsClient\Responses\Products\ProductResponse;
+use EFinancialsClient\Responses\Transactions\ListResponse as TransactionsListResponse;
+use EFinancialsClient\Responses\Transactions\TransactionResponse;
 use EFinancialsClient\Testing\ClientFake;
 use EFinancialsClient\Testing\Responses\Fixtures\Accounts\AccountResponseFixture;
 use EFinancialsClient\Testing\Responses\Fixtures\Bank\BankAccountResponseFixture;
 use EFinancialsClient\Testing\Responses\Fixtures\Clients\ClientResponseFixture;
+use EFinancialsClient\Testing\Responses\Fixtures\Journals\JournalResponseFixture;
 use EFinancialsClient\Testing\Responses\Fixtures\Products\ProductResponseFixture;
+use EFinancialsClient\Testing\Responses\Fixtures\Transactions\TransactionResponseFixture;
 use EFinancialsClient\Transporters\HttpTransporter;
 use EFinancialsClient\ValueObjects\ApiCredentials;
 use EFinancialsClient\ValueObjects\Transporter\BaseUri;
@@ -59,7 +66,7 @@ it('returns decoded json from a successful request', function () {
 
     $client = new Client($transporter);
 
-    expect($client->journals()->all())->toBe(['ok' => true]);
+    expect($client->salesInvoices()->all())->toBe(['ok' => true]);
 });
 
 it('throws a typed exception for http errors', function () {
@@ -73,7 +80,7 @@ it('throws a typed exception for http errors', function () {
     );
 
     $client = new Client($transporter);
-    $client->journals()->all();
+    $client->salesInvoices()->all();
 })->throws(ErrorException::class, 'Unauthorized');
 
 it('exposes resource accessors', function () {
@@ -218,6 +225,74 @@ it('maps products to a fuller OpenAPI projection', function () {
 
     $fake->assertSent('products', fn (Payload $payload): bool => $payload->method()->value === 'GET');
     $fake->assertSent('products/36166', fn (Payload $payload): bool => $payload->method()->value === 'GET');
+});
+
+it('maps journals to a fuller OpenAPI projection', function () {
+    $fake = new ClientFake([
+        JournalsListResponse::fake(),
+        JournalResponse::fake(),
+    ]);
+
+    $list = $fake->journals()->all();
+
+    expect($list)->toBeInstanceOf(JournalsListResponse::class)
+        ->and($list->items)->toHaveCount(1)
+        ->and($list->items[0])->toBeInstanceOf(JournalResponse::class)
+        ->and($list->items[0]->id)->toBe(739)
+        ->and($list->items[0]->number)->toBe(10008)
+        ->and($list->items[0]->operationType)->toBe('EMTA_VAT_DECLARATION')
+        ->and($list->items[0]->registered)->toBeTrue()
+        ->and($list->items[0]->postings)->toHaveCount(2)
+        ->and($list->items[0]->postings[0])->toBeInstanceOf(PostingResponse::class)
+        ->and($list->items[0]->postings[0]->accountsId)->toBe(2511)
+        ->and($list->items[0]->postings[0]->type)->toBe('D')
+        ->and($list->items[0]->isDeleted)->toBeFalse()
+        ->and($list->items[0]->toArray())->toBe(
+            JournalResponse::from(JournalResponseFixture::ATTRIBUTES)->toArray()
+        );
+
+    $journal = $fake->journals()->get(739);
+
+    expect($journal)->toBeInstanceOf(JournalResponse::class)
+        ->and($journal->documentNumber)->toBe('EMTA KMD 31.05.2014')
+        ->and($journal->insertDate)->toBe('2014-06-20')
+        ->and($journal->registerDate)->toBe('2014-10-29');
+
+    $fake->assertSent('journals', fn (Payload $payload): bool => $payload->method()->value === 'GET');
+    $fake->assertSent('journals/739', fn (Payload $payload): bool => $payload->method()->value === 'GET');
+});
+
+it('maps transactions to a fuller OpenAPI projection', function () {
+    $fake = new ClientFake([
+        TransactionsListResponse::fake(),
+        TransactionResponse::fake(),
+    ]);
+
+    $list = $fake->transactions()->all();
+
+    expect($list)->toBeInstanceOf(TransactionsListResponse::class)
+        ->and($list->items)->toHaveCount(1)
+        ->and($list->items[0])->toBeInstanceOf(TransactionResponse::class)
+        ->and($list->items[0]->id)->toBe(2672)
+        ->and($list->items[0]->accountsId)->toBe(1010)
+        ->and($list->items[0]->amount)->toBe(2348.32)
+        ->and($list->items[0]->status)->toBe('CONFIRMED')
+        ->and($list->items[0]->type)->toBe('D')
+        ->and($list->items[0]->isDeleted)->toBeFalse()
+        ->and($list->items[0]->items)->toBe([])
+        ->and($list->items[0]->toArray())->toBe(
+            TransactionResponse::from(TransactionResponseFixture::ATTRIBUTES)->toArray()
+        );
+
+    $transaction = $fake->transactions()->get(2672);
+
+    expect($transaction)->toBeInstanceOf(TransactionResponse::class)
+        ->and($transaction->clCurrenciesId)->toBe('EUR')
+        ->and($transaction->date)->toBe('2015-01-31')
+        ->and($transaction->operationType)->toBeNull();
+
+    $fake->assertSent('transactions', fn (Payload $payload): bool => $payload->method()->value === 'GET');
+    $fake->assertSent('transactions/2672', fn (Payload $payload): bool => $payload->method()->value === 'GET');
 });
 
 it('builds a client through the factory facade', function () {

--- a/tests/Integration/DemoApi.php
+++ b/tests/Integration/DemoApi.php
@@ -6,10 +6,12 @@ use EFinancialsClient\Responses\Bank\ListResponse as BankAccountsListResponse;
 use EFinancialsClient\Responses\Clients\ListResponse as ClientsListResponse;
 use EFinancialsClient\Responses\CostProfitCentres\ListResponse as CostProfitCentresListResponse;
 use EFinancialsClient\Responses\Currencies\ListResponse as CurrenciesListResponse;
+use EFinancialsClient\Responses\Journals\ListResponse as JournalsListResponse;
 use EFinancialsClient\Responses\Products\ListResponse as ProductsListResponse;
 use EFinancialsClient\Responses\PurchaseArticles\ListResponse as PurchaseArticlesListResponse;
 use EFinancialsClient\Responses\SalesArticles\ListResponse as SalesArticlesListResponse;
 use EFinancialsClient\Responses\Templates\ListResponse as TemplatesListResponse;
+use EFinancialsClient\Responses\Transactions\ListResponse as TransactionsListResponse;
 use EFinancialsClient\Responses\VatInfo\VatInfoResponse;
 
 $hasCredentials = is_string(getenv('E_FINANCIALS_API_KEY_ID') ?: null)
@@ -51,8 +53,8 @@ it('validates demo api response shapes', function () {
         ->and($client->purchaseArticles()->all())->toBeInstanceOf(PurchaseArticlesListResponse::class)
         ->and($client->invoices()->all())->toBeArray()
         ->and($client->invoices()->allSettings())->toBeArray()
-        ->and($client->journals()->all())->toBeArray()
-        ->and($client->transactions()->all())->toBeArray()
+        ->and($client->journals()->all())->toBeInstanceOf(JournalsListResponse::class)
+        ->and($client->transactions()->all())->toBeInstanceOf(TransactionsListResponse::class)
         ->and($client->salesInvoices()->all())->toBeArray()
         ->and($client->purchaseInvoices()->all())->toBeArray();
 })->skip(! $hasCredentials, 'Demo API credentials are not configured.');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds typed response DTOs for journals and transactions (OpenAPI `Journals` / `Postings` / `Transactions` / `TransactionsItems`), continuing the fuller OpenAPI projection after ClientFake redesign (#97) and invoice series/info DTOs (#98).

## Changes

- `JournalResponse` + nested `PostingResponse` — full schema properties plus example-backed `insert_date`, `register_date`, `is_deleted`
- Paginated `Journals\ListResponse`
- `TransactionResponse` + nested `TransactionItemResponse` — full schema properties plus example-backed `is_deleted`, `operation_type`
- Paginated `Transactions\ListResponse`
- Fixtures under `Testing/Responses/Fixtures/{Journals,Transactions}/`
- Resources + contracts return typed DTOs / `ApiResponse` / `ApiFileResponse`
- Fixes `updateFile` to pass the request body to `Payload::put`
- HTTP decode smoke tests moved to still-raw `salesInvoices()`

## Merge note

Rebased/merged latest `main` after #98. Conflicts were only additive test overlaps in `tests/Client.php` and `tests/Integration/DemoApi.php` (keep both invoice and journals/transactions coverage).

## Test plan

- [x] `composer test` (Pint, PHPStan, type coverage, Pest)
- [x] Live demo integration assertions for journals/transactions list shapes
- [ ] CI green
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc292-2ac0-79d0-9014-6126f82761ad?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc292-2ac0-79d0-9014-6126f82761ad&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

