### PR TITLE
feat: add PurchaseInvoices response DTOs

### DIFF
--- a/src/Contracts/Resources/PurchaseInvoicesContract.php
+++ b/src/Contracts/Resources/PurchaseInvoicesContract.php
@@ -5,6 +5,10 @@ declare(strict_types=1);
 namespace EFinancialsClient\Contracts\Resources;
 
 use DateTime;
+use EFinancialsClient\Responses\ApiFileResponse;
+use EFinancialsClient\Responses\ApiResponse;
+use EFinancialsClient\Responses\PurchaseInvoices\ListResponse;
+use EFinancialsClient\Responses\PurchaseInvoices\PurchaseInvoiceResponse;
 
 interface PurchaseInvoicesContract
 {
@@ -21,7 +25,7 @@ interface PurchaseInvoicesContract
      * @param  string  $paymentStatus  Object payment status.
      * @param  int|null  $clientsId  Supplier identificator.
      */
-    public function all(int $page = 1, DateTime|string $modifiedSince = '', DateTime|string $startDate = '', DateTime|string $endDate = '', string $status = '', string $paymentStatus = '', ?int $clientsId = null): mixed;
+    public function all(int $page = 1, DateTime|string $modifiedSince = '', DateTime|string $startDate = '', DateTime|string $endDate = '', string $status = '', string $paymentStatus = '', ?int $clientsId = null): ListResponse;
 
     /**
      * Retrieve one specific purchase invoice of the specified company.
@@ -30,24 +34,16 @@ interface PurchaseInvoicesContract
      *
      * @param  int  $id  Purchase invoice identificator.
      */
-    public function get(int $id): mixed;
+    public function get(int $id): PurchaseInvoiceResponse;
 
     /**
      * Create a new purchase invoice of the specified company.
      *
      * @see https://rmp-api.rik.ee/api.html#operation/post-purchase_invoices
      *
-     * @param array<string,mixed>|array{
-     *   "clients_id": 803,
-     *   "client_name": string,
-     *   "number": string,
-     *   "create_date": "2017-08-09",
-     *   "journal_date": "2017-08-09",
-     *   "term_days": 0,
-     *   "cl_currencies_id": "EUR"
-     * } $parameters
+     * @param  array<string, mixed>  $parameters
      */
-    public function create(array $parameters = []): mixed;
+    public function create(array $parameters = []): ApiResponse;
 
     /**
      * Modify one specific purchase invoice of the specified company.
@@ -55,17 +51,9 @@ interface PurchaseInvoicesContract
      * @see https://rmp-api.rik.ee/api.html#operation/patch-purchase_invoices_one
      *
      * @param  int  $id  Purchase invoice identificator.
-     * @param array<string,mixed>|array{
-     *   "clients_id": 803,
-     *   "client_name": string,
-     *   "number": string,
-     *   "create_date": "2017-08-09",
-     *   "journal_date": "2017-08-09",
-     *   "term_days": 0,
-     *   "cl_currencies_id": "EUR"
-     * } $parameters
+     * @param  array<string, mixed>  $parameters
      */
-    public function update(int $id, array $parameters): mixed;
+    public function update(int $id, array $parameters): ApiResponse;
 
     /**
      * Delete one specific purchase invoice of the specified company.
@@ -74,7 +62,7 @@ interface PurchaseInvoicesContract
      *
      * @param  int  $id  Purchase invoice identificator.
      */
-    public function delete(int $id): mixed;
+    public function delete(int $id): ApiResponse;
 
     /**
      * Register one specific purchase invoice of the specified company.
@@ -83,7 +71,7 @@ interface PurchaseInvoicesContract
      *
      * @param  int  $id  Purchase invoice identificator.
      */
-    public function register(int $id): mixed;
+    public function register(int $id): ApiResponse;
 
     /**
      * Invalidate one specific purchase invoice of the specified company.
@@ -92,7 +80,7 @@ interface PurchaseInvoicesContract
      *
      * @param  int  $id  Purchase invoice identificator.
      */
-    public function invalidate(int $id): mixed;
+    public function invalidate(int $id): ApiResponse;
 
     /**
      * Retrieve the user-uploaded document related to a purchase invoice.
@@ -101,7 +89,7 @@ interface PurchaseInvoicesContract
      *
      * @param  int  $id  Purchase invoice identificator.
      */
-    public function getFile(int $id): mixed;
+    public function getFile(int $id): ApiFileResponse;
 
     /**
      * Update the user-uploaded document related to a purchase invoice.
@@ -109,12 +97,9 @@ interface PurchaseInvoicesContract
      * @see https://rmp-api.rik.ee/api.html#operation/put-purchase_invoices_one_document_user
      *
      * @param  int  $id  Purchase invoice identificator.
-     * @param array<string,mixed>|array{
-     *   "name": string,
-     *   "contents": string,
-     * } $parameters Base64-encoded file payload.
+     * @param  array<string, mixed>  $parameters  Base64-encoded file payload.
      */
-    public function updateFile(int $id, array $parameters): mixed;
+    public function updateFile(int $id, array $parameters): ApiResponse;
 
     /**
      * Delete the user-uploaded document related to a purchase invoice.
@@ -123,5 +108,5 @@ interface PurchaseInvoicesContract
      *
      * @param  int  $id  Purchase invoice identificator.
      */
-    public function deleteFile(int $id): mixed;
+    public function deleteFile(int $id): ApiResponse;
 }

--- a/src/Resources/PurchaseInvoices.php
+++ b/src/Resources/PurchaseInvoices.php
@@ -5,9 +5,16 @@ declare(strict_types=1);
 namespace EFinancialsClient\Resources;
 
 use DateTime;
+use DateTimeInterface;
 use EFinancialsClient\Contracts\Resources\PurchaseInvoicesContract;
 use EFinancialsClient\Resources\Concerns\Transportable;
+use EFinancialsClient\Responses\ApiFileResponse;
+use EFinancialsClient\Responses\ApiResponse;
+use EFinancialsClient\Responses\PurchaseInvoices\ListResponse;
+use EFinancialsClient\Responses\PurchaseInvoices\PurchaseInvoiceResponse;
 use EFinancialsClient\ValueObjects\Transporter\Payload;
+use EFinancialsClient\ValueObjects\Transporter\Response;
+use InvalidArgumentException;
 
 final class PurchaseInvoices implements PurchaseInvoicesContract
 {
@@ -34,7 +41,7 @@ final class PurchaseInvoices implements PurchaseInvoicesContract
         string $status = '',
         string $paymentStatus = '',
         ?int $clientsId = null,
-    ): mixed {
+    ): ListResponse {
         $query = [];
 
         if ($page !== 1) {
@@ -43,7 +50,7 @@ final class PurchaseInvoices implements PurchaseInvoicesContract
 
         if ($modifiedSince !== '') {
             $query['modified_since'] = ($modifiedSince instanceof DateTime)
-                ? $modifiedSince->format(\DateTimeInterface::ATOM)
+                ? $modifiedSince->format(DateTimeInterface::ATOM)
                 : $modifiedSince;
         }
 
@@ -72,9 +79,11 @@ final class PurchaseInvoices implements PurchaseInvoicesContract
         }
 
         $payload = Payload::get('purchase_invoices', $query);
+
+        /** @var Response<array{current_page: int, total_pages: int, items: array<int, array<string, mixed>>}> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return ListResponse::from($response->data());
     }
 
     /**
@@ -84,12 +93,14 @@ final class PurchaseInvoices implements PurchaseInvoicesContract
      *
      * @param  int  $id  Purchase invoice identificator.
      */
-    public function get(int $id): mixed
+    public function get(int $id): PurchaseInvoiceResponse
     {
         $payload = Payload::get('purchase_invoices/'.$id);
+
+        /** @var Response<array<string, mixed>> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return PurchaseInvoiceResponse::from($response->data());
     }
 
     /**
@@ -97,17 +108,9 @@ final class PurchaseInvoices implements PurchaseInvoicesContract
      *
      * @see https://rmp-api.rik.ee/api.html#operation/post-purchase_invoices
      *
-     * @param array<string,mixed>|array{
-     *   "clients_id": 803,
-     *   "client_name": string,
-     *   "number": string,
-     *   "create_date": "2017-08-09",
-     *   "journal_date": "2017-08-09",
-     *   "term_days": 0,
-     *   "cl_currencies_id": "EUR"
-     * } $parameters
+     * @param  array<string, mixed>  $parameters
      */
-    public function create(array $parameters = []): mixed
+    public function create(array $parameters = []): ApiResponse
     {
         $missingRequiredParameters = array_diff_key(
             array_flip(
@@ -127,15 +130,17 @@ final class PurchaseInvoices implements PurchaseInvoicesContract
         if (count($missingRequiredParameters) !== 0) {
             $missingKeys = implode(', ', array_keys($missingRequiredParameters));
 
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 "Missing required parameter(s): $missingKeys"
             );
         }
 
         $payload = Payload::post('purchase_invoices', $parameters);
+
+        /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return ApiResponse::from($response->data());
     }
 
     /**
@@ -144,17 +149,9 @@ final class PurchaseInvoices implements PurchaseInvoicesContract
      * @see https://rmp-api.rik.ee/api.html#operation/patch-purchase_invoices_one
      *
      * @param  int  $id  Purchase invoice identificator.
-     * @param array<string,mixed>|array{
-     *   "clients_id": 803,
-     *   "client_name": string,
-     *   "number": string,
-     *   "create_date": "2017-08-09",
-     *   "journal_date": "2017-08-09",
-     *   "term_days": 0,
-     *   "cl_currencies_id": "EUR"
-     * } $parameters
+     * @param  array<string, mixed>  $parameters
      */
-    public function update(int $id, array $parameters): mixed
+    public function update(int $id, array $parameters): ApiResponse
     {
         $missingRequiredParameters = array_diff_key(
             array_flip(
@@ -174,15 +171,17 @@ final class PurchaseInvoices implements PurchaseInvoicesContract
         if (count($missingRequiredParameters) !== 0) {
             $missingKeys = implode(', ', array_keys($missingRequiredParameters));
 
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 "Missing required parameter(s): $missingKeys"
             );
         }
 
         $payload = Payload::patch('purchase_invoices/'.$id, $parameters);
+
+        /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return ApiResponse::from($response->data());
     }
 
     /**
@@ -192,12 +191,14 @@ final class PurchaseInvoices implements PurchaseInvoicesContract
      *
      * @param  int  $id  Purchase invoice identificator.
      */
-    public function delete(int $id): mixed
+    public function delete(int $id): ApiResponse
     {
         $payload = Payload::delete('purchase_invoices/'.$id);
+
+        /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return ApiResponse::from($response->data());
     }
 
     /**
@@ -207,12 +208,14 @@ final class PurchaseInvoices implements PurchaseInvoicesContract
      *
      * @param  int  $id  Purchase invoice identificator.
      */
-    public function register(int $id): mixed
+    public function register(int $id): ApiResponse
     {
         $payload = Payload::patch('purchase_invoices/'.$id.'/register');
+
+        /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return ApiResponse::from($response->data());
     }
 
     /**
@@ -222,12 +225,14 @@ final class PurchaseInvoices implements PurchaseInvoicesContract
      *
      * @param  int  $id  Purchase invoice identificator.
      */
-    public function invalidate(int $id): mixed
+    public function invalidate(int $id): ApiResponse
     {
         $payload = Payload::patch('purchase_invoices/'.$id.'/invalidate');
+
+        /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return ApiResponse::from($response->data());
     }
 
     /**
@@ -237,12 +242,14 @@ final class PurchaseInvoices implements PurchaseInvoicesContract
      *
      * @param  int  $id  Purchase invoice identificator.
      */
-    public function getFile(int $id): mixed
+    public function getFile(int $id): ApiFileResponse
     {
         $payload = Payload::get('purchase_invoices/'.$id.'/document_user');
+
+        /** @var Response<array{name: string, contents: string}> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return ApiFileResponse::from($response->data());
     }
 
     /**
@@ -251,12 +258,9 @@ final class PurchaseInvoices implements PurchaseInvoicesContract
      * @see https://rmp-api.rik.ee/api.html#operation/put-purchase_invoices_one_document_user
      *
      * @param  int  $id  Purchase invoice identificator.
-     * @param array<string,mixed>|array{
-     *   "name": string,
-     *   "contents": string,
-     * } $parameters Base64-encoded file payload.
+     * @param  array<string, mixed>  $parameters  Base64-encoded file payload.
      */
-    public function updateFile(int $id, array $parameters): mixed
+    public function updateFile(int $id, array $parameters): ApiResponse
     {
         $missingRequiredParameters = array_diff_key(
             array_flip(
@@ -271,15 +275,17 @@ final class PurchaseInvoices implements PurchaseInvoicesContract
         if (count($missingRequiredParameters) !== 0) {
             $missingKeys = implode(', ', array_keys($missingRequiredParameters));
 
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 "Missing required parameter(s): $missingKeys"
             );
         }
 
-        $payload = Payload::put('purchase_invoices/'.$id.'/document_user');
+        $payload = Payload::put('purchase_invoices/'.$id.'/document_user', $parameters);
+
+        /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return ApiResponse::from($response->data());
     }
 
     /**
@@ -289,11 +295,13 @@ final class PurchaseInvoices implements PurchaseInvoicesContract
      *
      * @param  int  $id  Purchase invoice identificator.
      */
-    public function deleteFile(int $id): mixed
+    public function deleteFile(int $id): ApiResponse
     {
         $payload = Payload::delete('purchase_invoices/'.$id.'/document_user');
+
+        /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return ApiResponse::from($response->data());
     }
 }

--- a/src/Responses/Concerns/NormalizesAttributes.php
+++ b/src/Responses/Concerns/NormalizesAttributes.php
@@ -117,6 +117,30 @@ trait NormalizesAttributes
     }
 
     /**
+     * @return array<int, int>
+     */
+    private static function intList(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        $list = [];
+
+        foreach ($value as $item) {
+            $int = self::intOrNull($item);
+
+            if ($int === null) {
+                continue;
+            }
+
+            $list[] = $int;
+        }
+
+        return $list;
+    }
+
+    /**
      * @return array<string, string>
      */
     private static function stringMap(mixed $value): array

--- a/src/Responses/PurchaseInvoices/ListResponse.php
+++ b/src/Responses/PurchaseInvoices/ListResponse.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Responses\PurchaseInvoices;
+
+use EFinancialsClient\Contracts\ResponseContract;
+use EFinancialsClient\Responses\Concerns\ArrayAccessible;
+use EFinancialsClient\Responses\Concerns\NormalizesAttributes;
+use EFinancialsClient\Testing\Responses\Concerns\Fakeable;
+
+/**
+ * @phpstan-import-type PurchaseInvoiceData from PurchaseInvoiceResponse
+ *
+ * @implements ResponseContract<array{current_page: int, total_pages: int, items: array<int, PurchaseInvoiceData>}>
+ */
+final class ListResponse implements ResponseContract
+{
+    /**
+     * @use ArrayAccessible<array{current_page: int, total_pages: int, items: array<int, PurchaseInvoiceData>}>
+     */
+    use ArrayAccessible;
+
+    use Fakeable;
+    use NormalizesAttributes;
+
+    /**
+     * @param  array<int, PurchaseInvoiceResponse>  $items
+     */
+    private function __construct(
+        public readonly int $currentPage,
+        public readonly int $totalPages,
+        public readonly array $items,
+    ) {}
+
+    /**
+     * @param  array<array-key, mixed>  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        /** @var array<int, array<string, mixed>> $rawItems */
+        $rawItems = is_array($attributes['items'] ?? null) ? $attributes['items'] : [];
+
+        $items = array_map(
+            static fn (array $item): PurchaseInvoiceResponse => PurchaseInvoiceResponse::from($item),
+            $rawItems,
+        );
+
+        return new self(
+            self::intValue($attributes['current_page'] ?? 0),
+            self::intValue($attributes['total_pages'] ?? 0),
+            $items,
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toArray(): array
+    {
+        return [
+            'current_page' => $this->currentPage,
+            'total_pages' => $this->totalPages,
+            'items' => array_map(
+                static fn (PurchaseInvoiceResponse $invoice): array => $invoice->toArray(),
+                $this->items,
+            ),
+        ];
+    }
+}

--- a/src/Responses/PurchaseInvoices/PurchaseInvoiceItemResponse.php
+++ b/src/Responses/PurchaseInvoices/PurchaseInvoiceItemResponse.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Responses\PurchaseInvoices;
+
+use EFinancialsClient\Contracts\ResponseContract;
+use EFinancialsClient\Responses\Concerns\ArrayAccessible;
+use EFinancialsClient\Responses\Concerns\NormalizesAttributes;
+use EFinancialsClient\Testing\Responses\Concerns\Fakeable;
+
+/**
+ * Full projection of the OpenAPI `PurchaseInvoicesItems` schema.
+ *
+ * @see https://rmp-api.rik.ee/openapi.yaml
+ *
+ * @phpstan-type PurchaseInvoiceItemData array{
+ *     id: int|null,
+ *     cl_purchase_articles_id: int|null,
+ *     purchase_accounts_id: int|null,
+ *     purchase_accounts_dimensions_id: int|null,
+ *     cl_fringe_benefits_id: int|null,
+ *     amount: float|null,
+ *     unit: string|null,
+ *     unit_net_price: float|null,
+ *     total_net_price: float|null,
+ *     base_total_net_price: float|null,
+ *     cl_vat_articles_id: int|null,
+ *     vat_accounts_id: int|null,
+ *     vat_accounts_dimensions_id: int|null,
+ *     vat_rate_dropdown: string|null,
+ *     vat_rate: float|null,
+ *     custom_title: string|null,
+ *     projects_project_id: int|null,
+ *     projects_location_id: int|null,
+ *     projects_person_id: int|null,
+ *     reversed_vat_id: int|null,
+ *     products_id: int|null,
+ *     project_no_vat_gross_price: float|null
+ * }
+ *
+ * @implements ResponseContract<PurchaseInvoiceItemData>
+ */
+final class PurchaseInvoiceItemResponse implements ResponseContract
+{
+    /**
+     * @use ArrayAccessible<PurchaseInvoiceItemData>
+     */
+    use ArrayAccessible;
+
+    use Fakeable;
+    use NormalizesAttributes;
+
+    private function __construct(
+        public readonly ?int $id,
+        public readonly ?int $clPurchaseArticlesId,
+        public readonly ?int $purchaseAccountsId,
+        public readonly ?int $purchaseAccountsDimensionsId,
+        public readonly ?int $clFringeBenefitsId,
+        public readonly ?float $amount,
+        public readonly ?string $unit,
+        public readonly ?float $unitNetPrice,
+        public readonly ?float $totalNetPrice,
+        public readonly ?float $baseTotalNetPrice,
+        public readonly ?int $clVatArticlesId,
+        public readonly ?int $vatAccountsId,
+        public readonly ?int $vatAccountsDimensionsId,
+        public readonly ?string $vatRateDropdown,
+        public readonly ?float $vatRate,
+        public readonly ?string $customTitle,
+        public readonly ?int $projectsProjectId,
+        public readonly ?int $projectsLocationId,
+        public readonly ?int $projectsPersonId,
+        public readonly ?int $reversedVatId,
+        public readonly ?int $productsId,
+        public readonly ?float $projectNoVatGrossPrice,
+    ) {}
+
+    /**
+     * @param  array<array-key, mixed>  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            self::intOrNull($attributes['id'] ?? null),
+            self::intOrNull($attributes['cl_purchase_articles_id'] ?? null),
+            self::intOrNull($attributes['purchase_accounts_id'] ?? null),
+            self::intOrNull($attributes['purchase_accounts_dimensions_id'] ?? null),
+            self::intOrNull($attributes['cl_fringe_benefits_id'] ?? null),
+            self::floatOrNull($attributes['amount'] ?? null),
+            self::stringOrNull($attributes['unit'] ?? null),
+            self::floatOrNull($attributes['unit_net_price'] ?? null),
+            self::floatOrNull($attributes['total_net_price'] ?? null),
+            self::floatOrNull($attributes['base_total_net_price'] ?? null),
+            self::intOrNull($attributes['cl_vat_articles_id'] ?? null),
+            self::intOrNull($attributes['vat_accounts_id'] ?? null),
+            self::intOrNull($attributes['vat_accounts_dimensions_id'] ?? null),
+            self::stringOrNull($attributes['vat_rate_dropdown'] ?? null),
+            self::floatOrNull($attributes['vat_rate'] ?? null),
+            self::stringOrNull($attributes['custom_title'] ?? null),
+            self::intOrNull($attributes['projects_project_id'] ?? null),
+            self::intOrNull($attributes['projects_location_id'] ?? null),
+            self::intOrNull($attributes['projects_person_id'] ?? null),
+            self::intOrNull($attributes['reversed_vat_id'] ?? null),
+            self::intOrNull($attributes['products_id'] ?? null),
+            self::floatOrNull($attributes['project_no_vat_gross_price'] ?? null),
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'cl_purchase_articles_id' => $this->clPurchaseArticlesId,
+            'purchase_accounts_id' => $this->purchaseAccountsId,
+            'purchase_accounts_dimensions_id' => $this->purchaseAccountsDimensionsId,
+            'cl_fringe_benefits_id' => $this->clFringeBenefitsId,
+            'amount' => $this->amount,
+            'unit' => $this->unit,
+            'unit_net_price' => $this->unitNetPrice,
+            'total_net_price' => $this->totalNetPrice,
+            'base_total_net_price' => $this->baseTotalNetPrice,
+            'cl_vat_articles_id' => $this->clVatArticlesId,
+            'vat_accounts_id' => $this->vatAccountsId,
+            'vat_accounts_dimensions_id' => $this->vatAccountsDimensionsId,
+            'vat_rate_dropdown' => $this->vatRateDropdown,
+            'vat_rate' => $this->vatRate,
+            'custom_title' => $this->customTitle,
+            'projects_project_id' => $this->projectsProjectId,
+            'projects_location_id' => $this->projectsLocationId,
+            'projects_person_id' => $this->projectsPersonId,
+            'reversed_vat_id' => $this->reversedVatId,
+            'products_id' => $this->productsId,
+            'project_no_vat_gross_price' => $this->projectNoVatGrossPrice,
+        ];
+    }
+}

--- a/src/Responses/PurchaseInvoices/PurchaseInvoiceResponse.php
+++ b/src/Responses/PurchaseInvoices/PurchaseInvoiceResponse.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Responses\PurchaseInvoices;
+
+use EFinancialsClient\Contracts\ResponseContract;
+use EFinancialsClient\Responses\Concerns\ArrayAccessible;
+use EFinancialsClient\Responses\Concerns\NormalizesAttributes;
+use EFinancialsClient\Testing\Responses\Concerns\Fakeable;
+
+/**
+ * Full projection of the OpenAPI `PurchaseInvoices` schema.
+ *
+ * @see https://rmp-api.rik.ee/api.html#operation/get-purchase_invoices_one
+ *
+ * @phpstan-import-type PurchaseInvoiceItemData from PurchaseInvoiceItemResponse
+ *
+ * @phpstan-type PurchaseInvoiceData array{
+ *     id: int|null,
+ *     base_document_files_id: int|null,
+ *     bank_payment_orders_id: int|null,
+ *     clients_id: int|null,
+ *     client_name: string|null,
+ *     number: string|null,
+ *     create_date: string|null,
+ *     journal_date: string|null,
+ *     status: string|null,
+ *     payment_status: string|null,
+ *     net_price: float|null,
+ *     vat_price: float|null,
+ *     gross_price: float|null,
+ *     payment_type: string|null,
+ *     bank_ref_number: string|null,
+ *     bank_account_no: string|null,
+ *     term_days: int|null,
+ *     overdue_charge: float|null,
+ *     notes: string|null,
+ *     paid_in_cash: bool|null,
+ *     cash_accounts_id: int|null,
+ *     cash_accounts_dimensions_id: int|null,
+ *     liability_accounts_id: int|null,
+ *     liability_accounts_dimensions_id: int|null,
+ *     cl_currencies_id: string|null,
+ *     currency_rate: float|null,
+ *     base_net_price: float|null,
+ *     base_vat_price: float|null,
+ *     base_gross_price: float|null,
+ *     cash_payment_date: string|null,
+ *     subclients_id: int|null,
+ *     is_xls_imported: bool|null,
+ *     items: array<int, PurchaseInvoiceItemData>,
+ *     journals: array<int, int>,
+ *     settlements: array<int, int>,
+ *     transactions: array<int, int>
+ * }
+ *
+ * @implements ResponseContract<PurchaseInvoiceData>
+ */
+final class PurchaseInvoiceResponse implements ResponseContract
+{
+    /**
+     * @use ArrayAccessible<PurchaseInvoiceData>
+     */
+    use ArrayAccessible;
+
+    use Fakeable;
+    use NormalizesAttributes;
+
+    /**
+     * @param  array<int, PurchaseInvoiceItemResponse>  $items
+     * @param  array<int, int>  $journals
+     * @param  array<int, int>  $settlements
+     * @param  array<int, int>  $transactions
+     */
+    private function __construct(
+        public readonly ?int $id,
+        public readonly ?int $baseDocumentFilesId,
+        public readonly ?int $bankPaymentOrdersId,
+        public readonly ?int $clientsId,
+        public readonly ?string $clientName,
+        public readonly ?string $number,
+        public readonly ?string $createDate,
+        public readonly ?string $journalDate,
+        public readonly ?string $status,
+        public readonly ?string $paymentStatus,
+        public readonly ?float $netPrice,
+        public readonly ?float $vatPrice,
+        public readonly ?float $grossPrice,
+        public readonly ?string $paymentType,
+        public readonly ?string $bankRefNumber,
+        public readonly ?string $bankAccountNo,
+        public readonly ?int $termDays,
+        public readonly ?float $overdueCharge,
+        public readonly ?string $notes,
+        public readonly ?bool $paidInCash,
+        public readonly ?int $cashAccountsId,
+        public readonly ?int $cashAccountsDimensionsId,
+        public readonly ?int $liabilityAccountsId,
+        public readonly ?int $liabilityAccountsDimensionsId,
+        public readonly ?string $clCurrenciesId,
+        public readonly ?float $currencyRate,
+        public readonly ?float $baseNetPrice,
+        public readonly ?float $baseVatPrice,
+        public readonly ?float $baseGrossPrice,
+        public readonly ?string $cashPaymentDate,
+        public readonly ?int $subclientsId,
+        public readonly ?bool $isXlsImported,
+        public readonly array $items,
+        public readonly array $journals,
+        public readonly array $settlements,
+        public readonly array $transactions,
+    ) {}
+
+    /**
+     * @param  array<array-key, mixed>  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        /** @var array<int, array<string, mixed>> $rawItems */
+        $rawItems = is_array($attributes['items'] ?? null) ? $attributes['items'] : [];
+
+        $items = array_values(array_map(
+            static fn (array $item): PurchaseInvoiceItemResponse => PurchaseInvoiceItemResponse::from($item),
+            $rawItems,
+        ));
+
+        return new self(
+            self::intOrNull($attributes['id'] ?? null),
+            self::intOrNull($attributes['base_document_files_id'] ?? null),
+            self::intOrNull($attributes['bank_payment_orders_id'] ?? null),
+            self::intOrNull($attributes['clients_id'] ?? null),
+            self::stringOrNull($attributes['client_name'] ?? null),
+            self::stringOrNull($attributes['number'] ?? null),
+            self::stringOrNull($attributes['create_date'] ?? null),
+            self::stringOrNull($attributes['journal_date'] ?? null),
+            self::stringOrNull($attributes['status'] ?? null),
+            self::stringOrNull($attributes['payment_status'] ?? null),
+            self::floatOrNull($attributes['net_price'] ?? null),
+            self::floatOrNull($attributes['vat_price'] ?? null),
+            self::floatOrNull($attributes['gross_price'] ?? null),
+            self::stringOrNull($attributes['payment_type'] ?? null),
+            self::stringOrNull($attributes['bank_ref_number'] ?? null),
+            self::stringOrNull($attributes['bank_account_no'] ?? null),
+            self::intOrNull($attributes['term_days'] ?? null),
+            self::floatOrNull($attributes['overdue_charge'] ?? null),
+            self::stringOrNull($attributes['notes'] ?? null),
+            self::boolOrNull($attributes['paid_in_cash'] ?? null),
+            self::intOrNull($attributes['cash_accounts_id'] ?? null),
+            self::intOrNull($attributes['cash_accounts_dimensions_id'] ?? null),
+            self::intOrNull($attributes['liability_accounts_id'] ?? null),
+            self::intOrNull($attributes['liability_accounts_dimensions_id'] ?? null),
+            self::stringOrNull($attributes['cl_currencies_id'] ?? null),
+            self::floatOrNull($attributes['currency_rate'] ?? null),
+            self::floatOrNull($attributes['base_net_price'] ?? null),
+            self::floatOrNull($attributes['base_vat_price'] ?? null),
+            self::floatOrNull($attributes['base_gross_price'] ?? null),
+            self::stringOrNull($attributes['cash_payment_date'] ?? null),
+            self::intOrNull($attributes['subclients_id'] ?? null),
+            self::boolOrNull($attributes['is_xls_imported'] ?? null),
+            $items,
+            self::intList($attributes['journals'] ?? null),
+            self::intList($attributes['settlements'] ?? null),
+            self::intList($attributes['transactions'] ?? null),
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'base_document_files_id' => $this->baseDocumentFilesId,
+            'bank_payment_orders_id' => $this->bankPaymentOrdersId,
+            'clients_id' => $this->clientsId,
+            'client_name' => $this->clientName,
+            'number' => $this->number,
+            'create_date' => $this->createDate,
+            'journal_date' => $this->journalDate,
+            'status' => $this->status,
+            'payment_status' => $this->paymentStatus,
+            'net_price' => $this->netPrice,
+            'vat_price' => $this->vatPrice,
+            'gross_price' => $this->grossPrice,
+            'payment_type' => $this->paymentType,
+            'bank_ref_number' => $this->bankRefNumber,
+            'bank_account_no' => $this->bankAccountNo,
+            'term_days' => $this->termDays,
+            'overdue_charge' => $this->overdueCharge,
+            'notes' => $this->notes,
+            'paid_in_cash' => $this->paidInCash,
+            'cash_accounts_id' => $this->cashAccountsId,
+            'cash_accounts_dimensions_id' => $this->cashAccountsDimensionsId,
+            'liability_accounts_id' => $this->liabilityAccountsId,
+            'liability_accounts_dimensions_id' => $this->liabilityAccountsDimensionsId,
+            'cl_currencies_id' => $this->clCurrenciesId,
+            'currency_rate' => $this->currencyRate,
+            'base_net_price' => $this->baseNetPrice,
+            'base_vat_price' => $this->baseVatPrice,
+            'base_gross_price' => $this->baseGrossPrice,
+            'cash_payment_date' => $this->cashPaymentDate,
+            'subclients_id' => $this->subclientsId,
+            'is_xls_imported' => $this->isXlsImported,
+            'items' => array_map(
+                static fn (PurchaseInvoiceItemResponse $item): array => $item->toArray(),
+                $this->items,
+            ),
+            'journals' => $this->journals,
+            'settlements' => $this->settlements,
+            'transactions' => $this->transactions,
+        ];
+    }
+}

--- a/src/Testing/Responses/Fixtures/PurchaseInvoices/ListResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/PurchaseInvoices/ListResponseFixture.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Testing\Responses\Fixtures\PurchaseInvoices;
+
+final class ListResponseFixture
+{
+    /**
+     * @var array{current_page: int, total_pages: int, items: array<int, array<string, mixed>>}
+     */
+    public const ATTRIBUTES = [
+        'current_page' => 1,
+        'total_pages' => 1,
+        'items' => [
+            PurchaseInvoiceResponseFixture::ATTRIBUTES,
+        ],
+    ];
+}

--- a/src/Testing/Responses/Fixtures/PurchaseInvoices/PurchaseInvoiceItemResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/PurchaseInvoices/PurchaseInvoiceItemResponseFixture.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Testing\Responses\Fixtures\PurchaseInvoices;
+
+/**
+ * OpenAPI `PurchaseInvoicesItems` schema projection.
+ *
+ * @see https://rmp-api.rik.ee/openapi.yaml
+ */
+final class PurchaseInvoiceItemResponseFixture
+{
+    /**
+     * @var array<string, mixed>
+     */
+    public const ATTRIBUTES = [
+        'id' => 10,
+        'cl_purchase_articles_id' => 1,
+        'purchase_accounts_id' => 4010,
+        'purchase_accounts_dimensions_id' => null,
+        'cl_fringe_benefits_id' => null,
+        'amount' => 1.0,
+        'unit' => 'tk',
+        'unit_net_price' => 100.0,
+        'total_net_price' => 100.0,
+        'base_total_net_price' => 100.0,
+        'cl_vat_articles_id' => 1,
+        'vat_accounts_id' => null,
+        'vat_accounts_dimensions_id' => null,
+        'vat_rate_dropdown' => '20',
+        'vat_rate' => 20.0,
+        'custom_title' => 'Office supplies',
+        'projects_project_id' => null,
+        'projects_location_id' => null,
+        'projects_person_id' => null,
+        'reversed_vat_id' => null,
+        'products_id' => null,
+        'project_no_vat_gross_price' => null,
+    ];
+}

--- a/src/Testing/Responses/Fixtures/PurchaseInvoices/PurchaseInvoiceResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/PurchaseInvoices/PurchaseInvoiceResponseFixture.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Testing\Responses\Fixtures\PurchaseInvoices;
+
+/**
+ * OpenAPI `PurchaseInvoices` schema example (fuller projection).
+ *
+ * @see https://rmp-api.rik.ee/openapi.yaml
+ */
+final class PurchaseInvoiceResponseFixture
+{
+    /**
+     * @var array<string, mixed>
+     */
+    public const ATTRIBUTES = [
+        'id' => 1983,
+        'base_document_files_id' => null,
+        'bank_payment_orders_id' => null,
+        'clients_id' => 803,
+        'client_name' => 'Aktsiaselts Kaupmees & Ko',
+        'number' => '234234',
+        'create_date' => '2017-08-09',
+        'journal_date' => '2017-08-09',
+        'status' => 'CONFIRMED',
+        'payment_status' => 'PAID',
+        'net_price' => 0.0,
+        'vat_price' => 0.0,
+        'gross_price' => 0.0,
+        'payment_type' => null,
+        'bank_ref_number' => null,
+        'bank_account_no' => null,
+        'term_days' => 0,
+        'overdue_charge' => null,
+        'notes' => null,
+        'paid_in_cash' => false,
+        'cash_accounts_id' => null,
+        'cash_accounts_dimensions_id' => null,
+        'liability_accounts_id' => 2310,
+        'liability_accounts_dimensions_id' => null,
+        'cl_currencies_id' => 'EUR',
+        'currency_rate' => 1.0,
+        'base_net_price' => 0.0,
+        'base_vat_price' => 0.0,
+        'base_gross_price' => 0.0,
+        'cash_payment_date' => null,
+        'subclients_id' => null,
+        'is_xls_imported' => false,
+        'items' => [
+            PurchaseInvoiceItemResponseFixture::ATTRIBUTES,
+        ],
+        'journals' => [],
+        'settlements' => [],
+        'transactions' => [],
+    ];
+}

--- a/tests/Client.php
+++ b/tests/Client.php
@@ -25,6 +25,9 @@ use EFinancialsClient\Responses\Journals\ListResponse as JournalsListResponse;
 use EFinancialsClient\Responses\Journals\PostingResponse;
 use EFinancialsClient\Responses\Products\ListResponse as ProductsListResponse;
 use EFinancialsClient\Responses\Products\ProductResponse;
+use EFinancialsClient\Responses\PurchaseInvoices\ListResponse as PurchaseInvoicesListResponse;
+use EFinancialsClient\Responses\PurchaseInvoices\PurchaseInvoiceItemResponse;
+use EFinancialsClient\Responses\PurchaseInvoices\PurchaseInvoiceResponse;
 use EFinancialsClient\Responses\Transactions\ListResponse as TransactionsListResponse;
 use EFinancialsClient\Responses\Transactions\TransactionResponse;
 use EFinancialsClient\Testing\ClientFake;
@@ -35,6 +38,7 @@ use EFinancialsClient\Testing\Responses\Fixtures\Invoices\InvoiceInfoResponseFix
 use EFinancialsClient\Testing\Responses\Fixtures\Invoices\InvoiceSeriesResponseFixture;
 use EFinancialsClient\Testing\Responses\Fixtures\Journals\JournalResponseFixture;
 use EFinancialsClient\Testing\Responses\Fixtures\Products\ProductResponseFixture;
+use EFinancialsClient\Testing\Responses\Fixtures\PurchaseInvoices\PurchaseInvoiceResponseFixture;
 use EFinancialsClient\Testing\Responses\Fixtures\Transactions\TransactionResponseFixture;
 use EFinancialsClient\Transporters\HttpTransporter;
 use EFinancialsClient\ValueObjects\ApiCredentials;
@@ -338,6 +342,42 @@ it('maps transactions to a fuller OpenAPI projection', function () {
 
     $fake->assertSent('transactions', fn (Payload $payload): bool => $payload->method()->value === 'GET');
     $fake->assertSent('transactions/2672', fn (Payload $payload): bool => $payload->method()->value === 'GET');
+});
+
+it('maps purchase invoices to a fuller OpenAPI projection', function () {
+    $fake = new ClientFake([
+        PurchaseInvoicesListResponse::fake(),
+        PurchaseInvoiceResponse::fake(),
+    ]);
+
+    $list = $fake->purchaseInvoices()->all();
+
+    expect($list)->toBeInstanceOf(PurchaseInvoicesListResponse::class)
+        ->and($list->items)->toHaveCount(1)
+        ->and($list->items[0])->toBeInstanceOf(PurchaseInvoiceResponse::class)
+        ->and($list->items[0]->id)->toBe(1983)
+        ->and($list->items[0]->clientName)->toBe('Aktsiaselts Kaupmees & Ko')
+        ->and($list->items[0]->number)->toBe('234234')
+        ->and($list->items[0]->status)->toBe('CONFIRMED')
+        ->and($list->items[0]->paymentStatus)->toBe('PAID')
+        ->and($list->items[0]->items)->toHaveCount(1)
+        ->and($list->items[0]->items[0])->toBeInstanceOf(PurchaseInvoiceItemResponse::class)
+        ->and($list->items[0]->items[0]->customTitle)->toBe('Office supplies')
+        ->and($list->items[0]->toArray())->toBe(
+            PurchaseInvoiceResponse::from(PurchaseInvoiceResponseFixture::ATTRIBUTES)->toArray()
+        );
+
+    $invoice = $fake->purchaseInvoices()->get(1983);
+
+    expect($invoice)->toBeInstanceOf(PurchaseInvoiceResponse::class)
+        ->and($invoice->liabilityAccountsId)->toBe(2310)
+        ->and($invoice->clCurrenciesId)->toBe('EUR')
+        ->and($invoice->journals)->toBe([])
+        ->and($invoice->settlements)->toBe([])
+        ->and($invoice->transactions)->toBe([]);
+
+    $fake->assertSent('purchase_invoices', fn (Payload $payload): bool => $payload->method()->value === 'GET');
+    $fake->assertSent('purchase_invoices/1983', fn (Payload $payload): bool => $payload->method()->value === 'GET');
 });
 
 it('builds a client through the factory facade', function () {

--- a/tests/Integration/DemoApi.php
+++ b/tests/Integration/DemoApi.php
@@ -11,6 +11,7 @@ use EFinancialsClient\Responses\Invoices\ListResponse as InvoicesListResponse;
 use EFinancialsClient\Responses\Journals\ListResponse as JournalsListResponse;
 use EFinancialsClient\Responses\Products\ListResponse as ProductsListResponse;
 use EFinancialsClient\Responses\PurchaseArticles\ListResponse as PurchaseArticlesListResponse;
+use EFinancialsClient\Responses\PurchaseInvoices\ListResponse as PurchaseInvoicesListResponse;
 use EFinancialsClient\Responses\SalesArticles\ListResponse as SalesArticlesListResponse;
 use EFinancialsClient\Responses\Templates\ListResponse as TemplatesListResponse;
 use EFinancialsClient\Responses\Transactions\ListResponse as TransactionsListResponse;
@@ -58,5 +59,5 @@ it('validates demo api response shapes', function () {
         ->and($client->journals()->all())->toBeInstanceOf(JournalsListResponse::class)
         ->and($client->transactions()->all())->toBeInstanceOf(TransactionsListResponse::class)
         ->and($client->salesInvoices()->all())->toBeArray()
-        ->and($client->purchaseInvoices()->all())->toBeArray();
+        ->and($client->purchaseInvoices()->all())->toBeInstanceOf(PurchaseInvoicesListResponse::class);
 })->skip(! $hasCredentials, 'Demo API credentials are not configured.');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds typed response DTOs for purchase invoices (OpenAPI `PurchaseInvoices` / `PurchaseInvoicesItems`), continuing the fuller OpenAPI projection after journals/transactions (#99).

## Changes

- `PurchaseInvoiceResponse` — full schema properties including nested line items and related `journals` / `settlements` / `transactions` id arrays
- Nested `PurchaseInvoiceItemResponse` — full `PurchaseInvoicesItems` projection
- Paginated `PurchaseInvoices\ListResponse`
- Fixtures under `Testing/Responses/Fixtures/PurchaseInvoices/`
- Resource + contract return typed DTOs / `ApiResponse` / `ApiFileResponse`
- Adds `intList` helper on `NormalizesAttributes`
- Fixes `updateFile` to pass the request body to `Payload::put`

## Test plan

- [x] `composer test` (Pint, PHPStan, type coverage, Pest)
- [x] Live demo integration assertion for purchase invoices list shape
- [ ] CI green
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc292-2ac0-79d0-9014-6126f82761ad?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc292-2ac0-79d0-9014-6126f82761ad&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

