### PR TITLE
feat: add SalesInvoices response DTOs

### DIFF
--- a/src/Contracts/Resources/SalesInvoicesContract.php
+++ b/src/Contracts/Resources/SalesInvoicesContract.php
@@ -5,6 +5,11 @@ declare(strict_types=1);
 namespace EFinancialsClient\Contracts\Resources;
 
 use DateTime;
+use EFinancialsClient\Responses\ApiFileResponse;
+use EFinancialsClient\Responses\ApiResponse;
+use EFinancialsClient\Responses\SalesInvoices\ListResponse;
+use EFinancialsClient\Responses\SalesInvoices\SaleInvoiceDeliveryOptionsResponse;
+use EFinancialsClient\Responses\SalesInvoices\SaleInvoiceResponse;
 
 interface SalesInvoicesContract
 {
@@ -21,7 +26,7 @@ interface SalesInvoicesContract
      * @param  string  $paymentStatus  Object payment status.
      * @param  int|null  $clientsId  Customer identificator.
      */
-    public function all(int $page = 1, DateTime|string $modifiedSince = '', DateTime|string $startDate = '', DateTime|string $endDate = '', string $status = '', string $paymentStatus = '', ?int $clientsId = null): mixed;
+    public function all(int $page = 1, DateTime|string $modifiedSince = '', DateTime|string $startDate = '', DateTime|string $endDate = '', string $status = '', string $paymentStatus = '', ?int $clientsId = null): ListResponse;
 
     /**
      * Retrieve one specific sale invoice of the specified company.
@@ -30,27 +35,16 @@ interface SalesInvoicesContract
      *
      * @param  int  $id  Sale invoice identificator.
      */
-    public function get(int $id): mixed;
+    public function get(int $id): SaleInvoiceResponse;
 
     /**
      * Create a new sale invoice of the specified company.
      *
      * @see https://rmp-api.rik.ee/api.html#operation/post-sale_invoices
      *
-     * @param array<string,mixed>|array{
-     *   "sale_invoice_type": "INVOICE",
-     *   "cl_templates_id": 1,
-     *   "clients_id": 126,
-     *   "cl_countries_id": "EST",
-     *   "number_suffix": "91",
-     *   "create_date": "2016-02-15",
-     *   "journal_date": "2016-02-15",
-     *   "term_days": 30,
-     *   "cl_currencies_id": "EUR",
-     *   "show_client_balance": false
-     * } $parameters
+     * @param  array<string, mixed>  $parameters
      */
-    public function create(array $parameters = []): mixed;
+    public function create(array $parameters = []): ApiResponse;
 
     /**
      * Modify one specific sale invoice of the specified company.
@@ -58,20 +52,9 @@ interface SalesInvoicesContract
      * @see https://rmp-api.rik.ee/api.html#operation/patch-sale_invoices_one
      *
      * @param  int  $id  Sale invoice identificator.
-     * @param array<string,mixed>|array{
-     *   "sale_invoice_type": "INVOICE",
-     *   "cl_templates_id": 1,
-     *   "clients_id": 126,
-     *   "cl_countries_id": "EST",
-     *   "number_suffix": "91",
-     *   "create_date": "2016-02-15",
-     *   "journal_date": "2016-02-15",
-     *   "term_days": 30,
-     *   "cl_currencies_id": "EUR",
-     *   "show_client_balance": false
-     * } $parameters
+     * @param  array<string, mixed>  $parameters
      */
-    public function update(int $id, array $parameters): mixed;
+    public function update(int $id, array $parameters): ApiResponse;
 
     /**
      * Delete one specific sale invoice of the specified company.
@@ -80,7 +63,7 @@ interface SalesInvoicesContract
      *
      * @param  int  $id  Sale invoice identificator.
      */
-    public function delete(int $id): mixed;
+    public function delete(int $id): ApiResponse;
 
     /**
      * Register one specific sale invoice of the specified company.
@@ -89,7 +72,7 @@ interface SalesInvoicesContract
      *
      * @param  int  $id  Sale invoice identificator.
      */
-    public function register(int $id): mixed;
+    public function register(int $id): ApiResponse;
 
     /**
      * Invalidate one specific sale invoice of the specified company.
@@ -98,7 +81,7 @@ interface SalesInvoicesContract
      *
      * @param  int  $id  Sale invoice identificator.
      */
-    public function invalidate(int $id): mixed;
+    public function invalidate(int $id): ApiResponse;
 
     /**
      * Retrieve the system-generated XML e-invoice related to a sale invoice.
@@ -107,7 +90,7 @@ interface SalesInvoicesContract
      *
      * @param  int  $id  Sale invoice identificator.
      */
-    public function getXml(int $id): mixed;
+    public function getXml(int $id): ApiFileResponse;
 
     /**
      * Retrieve the system-generated PDF related to a sale invoice.
@@ -116,7 +99,7 @@ interface SalesInvoicesContract
      *
      * @param  int  $id  Sale invoice identificator.
      */
-    public function getSystemPdf(int $id): mixed;
+    public function getSystemPdf(int $id): ApiFileResponse;
 
     /**
      * Retrieve the user-uploaded document related to a sale invoice.
@@ -125,7 +108,7 @@ interface SalesInvoicesContract
      *
      * @param  int  $id  Sale invoice identificator.
      */
-    public function getFile(int $id): mixed;
+    public function getFile(int $id): ApiFileResponse;
 
     /**
      * Update the user-uploaded document related to a sale invoice.
@@ -133,12 +116,9 @@ interface SalesInvoicesContract
      * @see https://rmp-api.rik.ee/api.html#operation/put-sale_invoices_one_document_user
      *
      * @param  int  $id  Sale invoice identificator.
-     * @param array<string,mixed>|array{
-     *   "name": string,
-     *   "contents": string,
-     * } $parameters Base64-encoded file payload.
+     * @param  array<string, mixed>  $parameters  Base64-encoded file payload.
      */
-    public function updateFile(int $id, array $parameters): mixed;
+    public function updateFile(int $id, array $parameters): ApiResponse;
 
     /**
      * Delete the user-uploaded document related to a sale invoice.
@@ -147,7 +127,7 @@ interface SalesInvoicesContract
      *
      * @param  int  $id  Sale invoice identificator.
      */
-    public function deleteFile(int $id): mixed;
+    public function deleteFile(int $id): ApiResponse;
 
     /**
      * Retrieve delivery options for one specific sale invoice.
@@ -156,7 +136,7 @@ interface SalesInvoicesContract
      *
      * @param  int  $id  Sale invoice identificator.
      */
-    public function getDeliveryOptions(int $id): mixed;
+    public function getDeliveryOptions(int $id): SaleInvoiceDeliveryOptionsResponse;
 
     /**
      * Send one specific sale invoice to the customer.
@@ -164,13 +144,7 @@ interface SalesInvoicesContract
      * @see https://rmp-api.rik.ee/api.html#operation/patch-sale_invoices_one_deliver
      *
      * @param  int  $id  Sale invoice identificator.
-     * @param array<string,mixed>|array{
-     *   "send_einvoice": bool,
-     *   "send_email": bool,
-     *   "email_addresses": string,
-     *   "email_subject": string,
-     *   "email_body": string,
-     * } $parameters
+     * @param  array<string, mixed>  $parameters
      */
-    public function deliver(int $id, array $parameters): mixed;
+    public function deliver(int $id, array $parameters): ApiResponse;
 }

--- a/src/Resources/SalesInvoices.php
+++ b/src/Resources/SalesInvoices.php
@@ -5,9 +5,17 @@ declare(strict_types=1);
 namespace EFinancialsClient\Resources;
 
 use DateTime;
+use DateTimeInterface;
 use EFinancialsClient\Contracts\Resources\SalesInvoicesContract;
 use EFinancialsClient\Resources\Concerns\Transportable;
+use EFinancialsClient\Responses\ApiFileResponse;
+use EFinancialsClient\Responses\ApiResponse;
+use EFinancialsClient\Responses\SalesInvoices\ListResponse;
+use EFinancialsClient\Responses\SalesInvoices\SaleInvoiceDeliveryOptionsResponse;
+use EFinancialsClient\Responses\SalesInvoices\SaleInvoiceResponse;
 use EFinancialsClient\ValueObjects\Transporter\Payload;
+use EFinancialsClient\ValueObjects\Transporter\Response;
+use InvalidArgumentException;
 
 final class SalesInvoices implements SalesInvoicesContract
 {
@@ -34,7 +42,7 @@ final class SalesInvoices implements SalesInvoicesContract
         string $status = '',
         string $paymentStatus = '',
         ?int $clientsId = null,
-    ): mixed {
+    ): ListResponse {
         $query = [];
 
         if ($page !== 1) {
@@ -43,7 +51,7 @@ final class SalesInvoices implements SalesInvoicesContract
 
         if ($modifiedSince !== '') {
             $query['modified_since'] = ($modifiedSince instanceof DateTime)
-                ? $modifiedSince->format(\DateTimeInterface::ATOM)
+                ? $modifiedSince->format(DateTimeInterface::ATOM)
                 : $modifiedSince;
         }
 
@@ -72,9 +80,11 @@ final class SalesInvoices implements SalesInvoicesContract
         }
 
         $payload = Payload::get('sale_invoices', $query);
+
+        /** @var Response<array{current_page: int, total_pages: int, items: array<int, array<string, mixed>>}> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return ListResponse::from($response->data());
     }
 
     /**
@@ -84,12 +94,14 @@ final class SalesInvoices implements SalesInvoicesContract
      *
      * @param  int  $id  Sale invoice identificator.
      */
-    public function get(int $id): mixed
+    public function get(int $id): SaleInvoiceResponse
     {
         $payload = Payload::get('sale_invoices/'.$id);
+
+        /** @var Response<array<string, mixed>> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return SaleInvoiceResponse::from($response->data());
     }
 
     /**
@@ -97,20 +109,9 @@ final class SalesInvoices implements SalesInvoicesContract
      *
      * @see https://rmp-api.rik.ee/api.html#operation/post-sale_invoices
      *
-     * @param array<string,mixed>|array{
-     *   "sale_invoice_type": "INVOICE",
-     *   "cl_templates_id": 1,
-     *   "clients_id": 126,
-     *   "cl_countries_id": "EST",
-     *   "number_suffix": "91",
-     *   "create_date": "2016-02-15",
-     *   "journal_date": "2016-02-15",
-     *   "term_days": 30,
-     *   "cl_currencies_id": "EUR",
-     *   "show_client_balance": false
-     * } $parameters
+     * @param  array<string, mixed>  $parameters
      */
-    public function create(array $parameters = []): mixed
+    public function create(array $parameters = []): ApiResponse
     {
         $missingRequiredParameters = array_diff_key(
             array_flip(
@@ -133,15 +134,17 @@ final class SalesInvoices implements SalesInvoicesContract
         if (count($missingRequiredParameters) !== 0) {
             $missingKeys = implode(', ', array_keys($missingRequiredParameters));
 
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 "Missing required parameter(s): $missingKeys"
             );
         }
 
         $payload = Payload::post('sale_invoices', $parameters);
+
+        /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return ApiResponse::from($response->data());
     }
 
     /**
@@ -150,20 +153,9 @@ final class SalesInvoices implements SalesInvoicesContract
      * @see https://rmp-api.rik.ee/api.html#operation/patch-sale_invoices_one
      *
      * @param  int  $id  Sale invoice identificator.
-     * @param array<string,mixed>|array{
-     *   "sale_invoice_type": "INVOICE",
-     *   "cl_templates_id": 1,
-     *   "clients_id": 126,
-     *   "cl_countries_id": "EST",
-     *   "number_suffix": "91",
-     *   "create_date": "2016-02-15",
-     *   "journal_date": "2016-02-15",
-     *   "term_days": 30,
-     *   "cl_currencies_id": "EUR",
-     *   "show_client_balance": false
-     * } $parameters
+     * @param  array<string, mixed>  $parameters
      */
-    public function update(int $id, array $parameters): mixed
+    public function update(int $id, array $parameters): ApiResponse
     {
         $missingRequiredParameters = array_diff_key(
             array_flip(
@@ -186,15 +178,17 @@ final class SalesInvoices implements SalesInvoicesContract
         if (count($missingRequiredParameters) !== 0) {
             $missingKeys = implode(', ', array_keys($missingRequiredParameters));
 
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 "Missing required parameter(s): $missingKeys"
             );
         }
 
         $payload = Payload::patch('sale_invoices/'.$id, $parameters);
+
+        /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return ApiResponse::from($response->data());
     }
 
     /**
@@ -204,12 +198,14 @@ final class SalesInvoices implements SalesInvoicesContract
      *
      * @param  int  $id  Sale invoice identificator.
      */
-    public function delete(int $id): mixed
+    public function delete(int $id): ApiResponse
     {
         $payload = Payload::delete('sale_invoices/'.$id);
+
+        /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return ApiResponse::from($response->data());
     }
 
     /**
@@ -219,12 +215,14 @@ final class SalesInvoices implements SalesInvoicesContract
      *
      * @param  int  $id  Sale invoice identificator.
      */
-    public function register(int $id): mixed
+    public function register(int $id): ApiResponse
     {
         $payload = Payload::patch('sale_invoices/'.$id.'/register');
+
+        /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return ApiResponse::from($response->data());
     }
 
     /**
@@ -234,12 +232,14 @@ final class SalesInvoices implements SalesInvoicesContract
      *
      * @param  int  $id  Sale invoice identificator.
      */
-    public function invalidate(int $id): mixed
+    public function invalidate(int $id): ApiResponse
     {
         $payload = Payload::patch('sale_invoices/'.$id.'/invalidate');
+
+        /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return ApiResponse::from($response->data());
     }
 
     /**
@@ -249,12 +249,14 @@ final class SalesInvoices implements SalesInvoicesContract
      *
      * @param  int  $id  Sale invoice identificator.
      */
-    public function getXml(int $id): mixed
+    public function getXml(int $id): ApiFileResponse
     {
         $payload = Payload::get('sale_invoices/'.$id.'/xml');
+
+        /** @var Response<array{name: string, contents: string}> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return ApiFileResponse::from($response->data());
     }
 
     /**
@@ -264,12 +266,14 @@ final class SalesInvoices implements SalesInvoicesContract
      *
      * @param  int  $id  Sale invoice identificator.
      */
-    public function getSystemPdf(int $id): mixed
+    public function getSystemPdf(int $id): ApiFileResponse
     {
         $payload = Payload::get('sale_invoices/'.$id.'/pdf_system');
+
+        /** @var Response<array{name: string, contents: string}> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return ApiFileResponse::from($response->data());
     }
 
     /**
@@ -279,12 +283,14 @@ final class SalesInvoices implements SalesInvoicesContract
      *
      * @param  int  $id  Sale invoice identificator.
      */
-    public function getFile(int $id): mixed
+    public function getFile(int $id): ApiFileResponse
     {
         $payload = Payload::get('sale_invoices/'.$id.'/document_user');
+
+        /** @var Response<array{name: string, contents: string}> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return ApiFileResponse::from($response->data());
     }
 
     /**
@@ -293,12 +299,9 @@ final class SalesInvoices implements SalesInvoicesContract
      * @see https://rmp-api.rik.ee/api.html#operation/put-sale_invoices_one_document_user
      *
      * @param  int  $id  Sale invoice identificator.
-     * @param array<string,mixed>|array{
-     *   "name": string,
-     *   "contents": string,
-     * } $parameters Base64-encoded file payload.
+     * @param  array<string, mixed>  $parameters  Base64-encoded file payload.
      */
-    public function updateFile(int $id, array $parameters): mixed
+    public function updateFile(int $id, array $parameters): ApiResponse
     {
         $missingRequiredParameters = array_diff_key(
             array_flip(
@@ -313,15 +316,17 @@ final class SalesInvoices implements SalesInvoicesContract
         if (count($missingRequiredParameters) !== 0) {
             $missingKeys = implode(', ', array_keys($missingRequiredParameters));
 
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 "Missing required parameter(s): $missingKeys"
             );
         }
 
-        $payload = Payload::put('sale_invoices/'.$id.'/document_user');
+        $payload = Payload::put('sale_invoices/'.$id.'/document_user', $parameters);
+
+        /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return ApiResponse::from($response->data());
     }
 
     /**
@@ -331,12 +336,14 @@ final class SalesInvoices implements SalesInvoicesContract
      *
      * @param  int  $id  Sale invoice identificator.
      */
-    public function deleteFile(int $id): mixed
+    public function deleteFile(int $id): ApiResponse
     {
         $payload = Payload::delete('sale_invoices/'.$id.'/document_user');
+
+        /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return ApiResponse::from($response->data());
     }
 
     /**
@@ -346,12 +353,14 @@ final class SalesInvoices implements SalesInvoicesContract
      *
      * @param  int  $id  Sale invoice identificator.
      */
-    public function getDeliveryOptions(int $id): mixed
+    public function getDeliveryOptions(int $id): SaleInvoiceDeliveryOptionsResponse
     {
         $payload = Payload::get('sale_invoices/'.$id.'/delivery_options');
+
+        /** @var Response<array<string, mixed>> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return SaleInvoiceDeliveryOptionsResponse::from($response->data());
     }
 
     /**
@@ -360,15 +369,9 @@ final class SalesInvoices implements SalesInvoicesContract
      * @see https://rmp-api.rik.ee/api.html#operation/patch-sale_invoices_one_deliver
      *
      * @param  int  $id  Sale invoice identificator.
-     * @param array<string,mixed>|array{
-     *   "send_einvoice": bool,
-     *   "send_email": bool,
-     *   "email_addresses": string,
-     *   "email_subject": string,
-     *   "email_body": string,
-     * } $parameters
+     * @param  array<string, mixed>  $parameters
      */
-    public function deliver(int $id, array $parameters): mixed
+    public function deliver(int $id, array $parameters): ApiResponse
     {
         $missingRequiredParameters = array_diff_key(
             array_flip(
@@ -383,14 +386,16 @@ final class SalesInvoices implements SalesInvoicesContract
         if (count($missingRequiredParameters) !== 0) {
             $missingKeys = implode(', ', array_keys($missingRequiredParameters));
 
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 "Missing required parameter(s): $missingKeys"
             );
         }
 
         $payload = Payload::patch('sale_invoices/'.$id.'/deliver', $parameters);
+
+        /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
 
-        return $response->data();
+        return ApiResponse::from($response->data());
     }
 }

--- a/src/Responses/SalesInvoices/ListResponse.php
+++ b/src/Responses/SalesInvoices/ListResponse.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Responses\SalesInvoices;
+
+use EFinancialsClient\Contracts\ResponseContract;
+use EFinancialsClient\Responses\Concerns\ArrayAccessible;
+use EFinancialsClient\Responses\Concerns\NormalizesAttributes;
+use EFinancialsClient\Testing\Responses\Concerns\Fakeable;
+
+/**
+ * @phpstan-import-type SaleInvoiceData from SaleInvoiceResponse
+ *
+ * @implements ResponseContract<array{current_page: int, total_pages: int, items: array<int, SaleInvoiceData>}>
+ */
+final class ListResponse implements ResponseContract
+{
+    /**
+     * @use ArrayAccessible<array{current_page: int, total_pages: int, items: array<int, SaleInvoiceData>}>
+     */
+    use ArrayAccessible;
+
+    use Fakeable;
+    use NormalizesAttributes;
+
+    /**
+     * @param  array<int, SaleInvoiceResponse>  $items
+     */
+    private function __construct(
+        public readonly int $currentPage,
+        public readonly int $totalPages,
+        public readonly array $items,
+    ) {}
+
+    /**
+     * @param  array<array-key, mixed>  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        /** @var array<int, array<string, mixed>> $rawItems */
+        $rawItems = is_array($attributes['items'] ?? null) ? $attributes['items'] : [];
+
+        $items = array_map(
+            static fn (array $item): SaleInvoiceResponse => SaleInvoiceResponse::from($item),
+            $rawItems,
+        );
+
+        return new self(
+            self::intValue($attributes['current_page'] ?? 0),
+            self::intValue($attributes['total_pages'] ?? 0),
+            $items,
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toArray(): array
+    {
+        return [
+            'current_page' => $this->currentPage,
+            'total_pages' => $this->totalPages,
+            'items' => array_map(
+                static fn (SaleInvoiceResponse $invoice): array => $invoice->toArray(),
+                $this->items,
+            ),
+        ];
+    }
+}

--- a/src/Responses/SalesInvoices/SaleInvoiceDeliveryOptionsResponse.php
+++ b/src/Responses/SalesInvoices/SaleInvoiceDeliveryOptionsResponse.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Responses\SalesInvoices;
+
+use EFinancialsClient\Contracts\ResponseContract;
+use EFinancialsClient\Responses\Concerns\ArrayAccessible;
+use EFinancialsClient\Responses\Concerns\NormalizesAttributes;
+use EFinancialsClient\Testing\Responses\Concerns\Fakeable;
+
+/**
+ * Full projection of the OpenAPI `SaleInvoicesDeliveryOptions` schema.
+ *
+ * @see https://rmp-api.rik.ee/api.html#operation/get-sale_invoices_one_delivery_opts
+ *
+ * @phpstan-type SaleInvoiceDeliveryOptionsData array{
+ *     can_send_einvoice: bool,
+ *     can_send_einvoice_reason: string|null,
+ *     can_send_email: bool,
+ *     can_send_email_addresses: string|null
+ * }
+ *
+ * @implements ResponseContract<SaleInvoiceDeliveryOptionsData>
+ */
+final class SaleInvoiceDeliveryOptionsResponse implements ResponseContract
+{
+    /**
+     * @use ArrayAccessible<SaleInvoiceDeliveryOptionsData>
+     */
+    use ArrayAccessible;
+
+    use Fakeable;
+    use NormalizesAttributes;
+
+    private function __construct(
+        public readonly bool $canSendEinvoice,
+        public readonly ?string $canSendEinvoiceReason,
+        public readonly bool $canSendEmail,
+        public readonly ?string $canSendEmailAddresses,
+    ) {}
+
+    /**
+     * @param  array<array-key, mixed>  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            self::boolValue($attributes['can_send_einvoice'] ?? null),
+            self::stringOrNull($attributes['can_send_einvoice_reason'] ?? null),
+            self::boolValue($attributes['can_send_email'] ?? null),
+            self::stringOrNull($attributes['can_send_email_addresses'] ?? null),
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toArray(): array
+    {
+        return [
+            'can_send_einvoice' => $this->canSendEinvoice,
+            'can_send_einvoice_reason' => $this->canSendEinvoiceReason,
+            'can_send_email' => $this->canSendEmail,
+            'can_send_email_addresses' => $this->canSendEmailAddresses,
+        ];
+    }
+}

--- a/src/Responses/SalesInvoices/SaleInvoiceDeliveryResponse.php
+++ b/src/Responses/SalesInvoices/SaleInvoiceDeliveryResponse.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Responses\SalesInvoices;
+
+use EFinancialsClient\Contracts\ResponseContract;
+use EFinancialsClient\Responses\Concerns\ArrayAccessible;
+use EFinancialsClient\Responses\Concerns\NormalizesAttributes;
+use EFinancialsClient\Testing\Responses\Concerns\Fakeable;
+
+/**
+ * Full projection of the OpenAPI `SaleInvoicesDeliveries` schema.
+ *
+ * @see https://rmp-api.rik.ee/openapi.yaml
+ *
+ * @phpstan-type SaleInvoiceDeliveryData array{
+ *     create_date: string|null,
+ *     destination_type: string|null,
+ *     invoice_type: string|null,
+ *     receiver_address: string|null,
+ *     receiver_name: string|null,
+ *     send_method: int|null,
+ *     sender_person_code: string|null,
+ *     sender_person_name: string|null,
+ *     status_date: string|null,
+ *     transfer_status_code: int|null
+ * }
+ *
+ * @implements ResponseContract<SaleInvoiceDeliveryData>
+ */
+final class SaleInvoiceDeliveryResponse implements ResponseContract
+{
+    /**
+     * @use ArrayAccessible<SaleInvoiceDeliveryData>
+     */
+    use ArrayAccessible;
+
+    use Fakeable;
+    use NormalizesAttributes;
+
+    private function __construct(
+        public readonly ?string $createDate,
+        public readonly ?string $destinationType,
+        public readonly ?string $invoiceType,
+        public readonly ?string $receiverAddress,
+        public readonly ?string $receiverName,
+        public readonly ?int $sendMethod,
+        public readonly ?string $senderPersonCode,
+        public readonly ?string $senderPersonName,
+        public readonly ?string $statusDate,
+        public readonly ?int $transferStatusCode,
+    ) {}
+
+    /**
+     * @param  array<array-key, mixed>  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            self::stringOrNull($attributes['create_date'] ?? null),
+            self::stringOrNull($attributes['destination_type'] ?? null),
+            self::stringOrNull($attributes['invoice_type'] ?? null),
+            self::stringOrNull($attributes['receiver_address'] ?? null),
+            self::stringOrNull($attributes['receiver_name'] ?? null),
+            self::intOrNull($attributes['send_method'] ?? null),
+            self::stringOrNull($attributes['sender_person_code'] ?? null),
+            self::stringOrNull($attributes['sender_person_name'] ?? null),
+            self::stringOrNull($attributes['status_date'] ?? null),
+            self::intOrNull($attributes['transfer_status_code'] ?? null),
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toArray(): array
+    {
+        return [
+            'create_date' => $this->createDate,
+            'destination_type' => $this->destinationType,
+            'invoice_type' => $this->invoiceType,
+            'receiver_address' => $this->receiverAddress,
+            'receiver_name' => $this->receiverName,
+            'send_method' => $this->sendMethod,
+            'sender_person_code' => $this->senderPersonCode,
+            'sender_person_name' => $this->senderPersonName,
+            'status_date' => $this->statusDate,
+            'transfer_status_code' => $this->transferStatusCode,
+        ];
+    }
+}

--- a/src/Responses/SalesInvoices/SaleInvoiceItemResponse.php
+++ b/src/Responses/SalesInvoices/SaleInvoiceItemResponse.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Responses\SalesInvoices;
+
+use EFinancialsClient\Contracts\ResponseContract;
+use EFinancialsClient\Responses\Concerns\ArrayAccessible;
+use EFinancialsClient\Responses\Concerns\NormalizesAttributes;
+use EFinancialsClient\Testing\Responses\Concerns\Fakeable;
+
+/**
+ * Full projection of the OpenAPI `SaleInvoicesItems` schema.
+ *
+ * @see https://rmp-api.rik.ee/openapi.yaml
+ *
+ * @phpstan-type SaleInvoiceItemData array{
+ *     id: int|null,
+ *     products_id: int|null,
+ *     cl_sale_articles_id: int|null,
+ *     sale_accounts_id: int|null,
+ *     sale_accounts_dimensions_id: int|null,
+ *     amount: float|null,
+ *     unit: string|null,
+ *     unit_net_price: float|null,
+ *     total_net_price: float|null,
+ *     base_total_net_price: float|null,
+ *     vat_accounts_id: int|null,
+ *     vat_rate: float|null,
+ *     discount_percent: float|null,
+ *     discount_amount: float|null,
+ *     custom_title: string|null,
+ *     projects_project_id: int|null,
+ *     projects_location_id: int|null,
+ *     projects_person_id: int|null,
+ *     vat_amount: float|null
+ * }
+ *
+ * @implements ResponseContract<SaleInvoiceItemData>
+ */
+final class SaleInvoiceItemResponse implements ResponseContract
+{
+    /**
+     * @use ArrayAccessible<SaleInvoiceItemData>
+     */
+    use ArrayAccessible;
+
+    use Fakeable;
+    use NormalizesAttributes;
+
+    private function __construct(
+        public readonly ?int $id,
+        public readonly ?int $productsId,
+        public readonly ?int $clSaleArticlesId,
+        public readonly ?int $saleAccountsId,
+        public readonly ?int $saleAccountsDimensionsId,
+        public readonly ?float $amount,
+        public readonly ?string $unit,
+        public readonly ?float $unitNetPrice,
+        public readonly ?float $totalNetPrice,
+        public readonly ?float $baseTotalNetPrice,
+        public readonly ?int $vatAccountsId,
+        public readonly ?float $vatRate,
+        public readonly ?float $discountPercent,
+        public readonly ?float $discountAmount,
+        public readonly ?string $customTitle,
+        public readonly ?int $projectsProjectId,
+        public readonly ?int $projectsLocationId,
+        public readonly ?int $projectsPersonId,
+        public readonly ?float $vatAmount,
+    ) {}
+
+    /**
+     * @param  array<array-key, mixed>  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            self::intOrNull($attributes['id'] ?? null),
+            self::intOrNull($attributes['products_id'] ?? null),
+            self::intOrNull($attributes['cl_sale_articles_id'] ?? null),
+            self::intOrNull($attributes['sale_accounts_id'] ?? null),
+            self::intOrNull($attributes['sale_accounts_dimensions_id'] ?? null),
+            self::floatOrNull($attributes['amount'] ?? null),
+            self::stringOrNull($attributes['unit'] ?? null),
+            self::floatOrNull($attributes['unit_net_price'] ?? null),
+            self::floatOrNull($attributes['total_net_price'] ?? null),
+            self::floatOrNull($attributes['base_total_net_price'] ?? null),
+            self::intOrNull($attributes['vat_accounts_id'] ?? null),
+            self::floatOrNull($attributes['vat_rate'] ?? null),
+            self::floatOrNull($attributes['discount_percent'] ?? null),
+            self::floatOrNull($attributes['discount_amount'] ?? null),
+            self::stringOrNull($attributes['custom_title'] ?? null),
+            self::intOrNull($attributes['projects_project_id'] ?? null),
+            self::intOrNull($attributes['projects_location_id'] ?? null),
+            self::intOrNull($attributes['projects_person_id'] ?? null),
+            self::floatOrNull($attributes['vat_amount'] ?? null),
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'products_id' => $this->productsId,
+            'cl_sale_articles_id' => $this->clSaleArticlesId,
+            'sale_accounts_id' => $this->saleAccountsId,
+            'sale_accounts_dimensions_id' => $this->saleAccountsDimensionsId,
+            'amount' => $this->amount,
+            'unit' => $this->unit,
+            'unit_net_price' => $this->unitNetPrice,
+            'total_net_price' => $this->totalNetPrice,
+            'base_total_net_price' => $this->baseTotalNetPrice,
+            'vat_accounts_id' => $this->vatAccountsId,
+            'vat_rate' => $this->vatRate,
+            'discount_percent' => $this->discountPercent,
+            'discount_amount' => $this->discountAmount,
+            'custom_title' => $this->customTitle,
+            'projects_project_id' => $this->projectsProjectId,
+            'projects_location_id' => $this->projectsLocationId,
+            'projects_person_id' => $this->projectsPersonId,
+            'vat_amount' => $this->vatAmount,
+        ];
+    }
+}

--- a/src/Responses/SalesInvoices/SaleInvoiceResponse.php
+++ b/src/Responses/SalesInvoices/SaleInvoiceResponse.php
@@ -1,0 +1,360 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Responses\SalesInvoices;
+
+use EFinancialsClient\Contracts\ResponseContract;
+use EFinancialsClient\Responses\Concerns\ArrayAccessible;
+use EFinancialsClient\Responses\Concerns\NormalizesAttributes;
+use EFinancialsClient\Testing\Responses\Concerns\Fakeable;
+
+/**
+ * Full projection of the OpenAPI `SaleInvoices` schema, plus example-backed fields
+ * (`bank_accounts_id`, `triangulation_seller_invoice_vat_no`).
+ *
+ * @see https://rmp-api.rik.ee/api.html#operation/get-sale_invoices_one
+ *
+ * @phpstan-import-type SaleInvoiceItemData from SaleInvoiceItemResponse
+ * @phpstan-import-type SaleInvoiceDeliveryData from SaleInvoiceDeliveryResponse
+ *
+ * @phpstan-type SaleInvoiceData array{
+ *     id: int|null,
+ *     credit_sale_invoices_id: int|null,
+ *     credit_invoice_payment_type: string|null,
+ *     sale_invoice_type: string|null,
+ *     cl_templates_id: int|null,
+ *     clients_id: int|null,
+ *     client_name: string|null,
+ *     cl_countries_id: string|null,
+ *     number_prefix: string|null,
+ *     number_suffix: string|null,
+ *     number: string|null,
+ *     create_date: string|null,
+ *     journal_date: string|null,
+ *     status: string|null,
+ *     payment_status: string|null,
+ *     net_price: float|null,
+ *     vat5_price: float|null,
+ *     vat9_price: float|null,
+ *     vat20_price: float|null,
+ *     gross_price: float|null,
+ *     bank_ref_number: string|null,
+ *     term_days: int|null,
+ *     overdue_charge: float|null,
+ *     notes: string|null,
+ *     base_document_files_id: int|null,
+ *     files_id: int|null,
+ *     is_doubtful: bool|null,
+ *     is_hopeless: bool|null,
+ *     use_per_item_rounding: bool|null,
+ *     paid_in_cash: bool|null,
+ *     cash_accounts_id: int|null,
+ *     cash_accounts_dimensions_id: int|null,
+ *     invoice_info: string|null,
+ *     payment_description: string|null,
+ *     cl_currencies_id: string|null,
+ *     currency_rate: float|null,
+ *     base_gross_price: float|null,
+ *     base_net_price: float|null,
+ *     base_vat5_price: float|null,
+ *     base_vat9_price: float|null,
+ *     base_vat20_price: float|null,
+ *     cash_payment_date: string|null,
+ *     trade_secret: bool|null,
+ *     receivable_accounts_id: int|null,
+ *     receivable_accounts_dimensions_id: int|null,
+ *     intra_community_supply: bool|null,
+ *     client_vat_no: string|null,
+ *     triangulation: bool|null,
+ *     assembled_in_member_state: bool|null,
+ *     show_client_balance: bool|null,
+ *     subclients_id: int|null,
+ *     is_xls_imported: bool|null,
+ *     recipient_clients_id: int|null,
+ *     recipient_subclients_id: int|null,
+ *     contract_number: string|null,
+ *     invoice_content_code: string|null,
+ *     invoice_content_text: string|null,
+ *     period_start_date: string|null,
+ *     period_end_date: string|null,
+ *     additional_info_content: string|null,
+ *     bank_payment_orders_id: int|null,
+ *     bank_accounts_id: int|null,
+ *     triangulation_seller_invoice_vat_no: string|null,
+ *     items: array<int, SaleInvoiceItemData>,
+ *     deliveries: array<int, SaleInvoiceDeliveryData>,
+ *     credit_invoices: array<int, int>,
+ *     journals: array<int, int>,
+ *     settlements: array<int, int>,
+ *     transactions: array<int, int>
+ * }
+ *
+ * @implements ResponseContract<SaleInvoiceData>
+ */
+final class SaleInvoiceResponse implements ResponseContract
+{
+    /**
+     * @use ArrayAccessible<SaleInvoiceData>
+     */
+    use ArrayAccessible;
+
+    use Fakeable;
+    use NormalizesAttributes;
+
+    /**
+     * @param  array<int, SaleInvoiceItemResponse>  $items
+     * @param  array<int, SaleInvoiceDeliveryResponse>  $deliveries
+     * @param  array<int, int>  $creditInvoices
+     * @param  array<int, int>  $journals
+     * @param  array<int, int>  $settlements
+     * @param  array<int, int>  $transactions
+     */
+    private function __construct(
+        public readonly ?int $id,
+        public readonly ?int $creditSaleInvoicesId,
+        public readonly ?string $creditInvoicePaymentType,
+        public readonly ?string $saleInvoiceType,
+        public readonly ?int $clTemplatesId,
+        public readonly ?int $clientsId,
+        public readonly ?string $clientName,
+        public readonly ?string $clCountriesId,
+        public readonly ?string $numberPrefix,
+        public readonly ?string $numberSuffix,
+        public readonly ?string $number,
+        public readonly ?string $createDate,
+        public readonly ?string $journalDate,
+        public readonly ?string $status,
+        public readonly ?string $paymentStatus,
+        public readonly ?float $netPrice,
+        public readonly ?float $vat5Price,
+        public readonly ?float $vat9Price,
+        public readonly ?float $vat20Price,
+        public readonly ?float $grossPrice,
+        public readonly ?string $bankRefNumber,
+        public readonly ?int $termDays,
+        public readonly ?float $overdueCharge,
+        public readonly ?string $notes,
+        public readonly ?int $baseDocumentFilesId,
+        public readonly ?int $filesId,
+        public readonly ?bool $isDoubtful,
+        public readonly ?bool $isHopeless,
+        public readonly ?bool $usePerItemRounding,
+        public readonly ?bool $paidInCash,
+        public readonly ?int $cashAccountsId,
+        public readonly ?int $cashAccountsDimensionsId,
+        public readonly ?string $invoiceInfo,
+        public readonly ?string $paymentDescription,
+        public readonly ?string $clCurrenciesId,
+        public readonly ?float $currencyRate,
+        public readonly ?float $baseGrossPrice,
+        public readonly ?float $baseNetPrice,
+        public readonly ?float $baseVat5Price,
+        public readonly ?float $baseVat9Price,
+        public readonly ?float $baseVat20Price,
+        public readonly ?string $cashPaymentDate,
+        public readonly ?bool $tradeSecret,
+        public readonly ?int $receivableAccountsId,
+        public readonly ?int $receivableAccountsDimensionsId,
+        public readonly ?bool $intraCommunitySupply,
+        public readonly ?string $clientVatNo,
+        public readonly ?bool $triangulation,
+        public readonly ?bool $assembledInMemberState,
+        public readonly ?bool $showClientBalance,
+        public readonly ?int $subclientsId,
+        public readonly ?bool $isXlsImported,
+        public readonly ?int $recipientClientsId,
+        public readonly ?int $recipientSubclientsId,
+        public readonly ?string $contractNumber,
+        public readonly ?string $invoiceContentCode,
+        public readonly ?string $invoiceContentText,
+        public readonly ?string $periodStartDate,
+        public readonly ?string $periodEndDate,
+        public readonly ?string $additionalInfoContent,
+        public readonly ?int $bankPaymentOrdersId,
+        public readonly ?int $bankAccountsId,
+        public readonly ?string $triangulationSellerInvoiceVatNo,
+        public readonly array $items,
+        public readonly array $deliveries,
+        public readonly array $creditInvoices,
+        public readonly array $journals,
+        public readonly array $settlements,
+        public readonly array $transactions,
+    ) {}
+
+    /**
+     * @param  array<array-key, mixed>  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        /** @var array<int, array<string, mixed>> $rawItems */
+        $rawItems = is_array($attributes['items'] ?? null) ? $attributes['items'] : [];
+        $items = array_values(array_map(
+            static fn (array $item): SaleInvoiceItemResponse => SaleInvoiceItemResponse::from($item),
+            $rawItems,
+        ));
+
+        /** @var array<int, array<string, mixed>> $rawDeliveries */
+        $rawDeliveries = is_array($attributes['deliveries'] ?? null) ? $attributes['deliveries'] : [];
+        $deliveries = array_values(array_map(
+            static fn (array $delivery): SaleInvoiceDeliveryResponse => SaleInvoiceDeliveryResponse::from($delivery),
+            $rawDeliveries,
+        ));
+
+        return new self(
+            self::intOrNull($attributes['id'] ?? null),
+            self::intOrNull($attributes['credit_sale_invoices_id'] ?? null),
+            self::stringOrNull($attributes['credit_invoice_payment_type'] ?? null),
+            self::stringOrNull($attributes['sale_invoice_type'] ?? null),
+            self::intOrNull($attributes['cl_templates_id'] ?? null),
+            self::intOrNull($attributes['clients_id'] ?? null),
+            self::stringOrNull($attributes['client_name'] ?? null),
+            self::stringOrNull($attributes['cl_countries_id'] ?? null),
+            self::stringOrNull($attributes['number_prefix'] ?? null),
+            self::stringOrNull($attributes['number_suffix'] ?? null),
+            self::stringOrNull($attributes['number'] ?? null),
+            self::stringOrNull($attributes['create_date'] ?? null),
+            self::stringOrNull($attributes['journal_date'] ?? null),
+            self::stringOrNull($attributes['status'] ?? null),
+            self::stringOrNull($attributes['payment_status'] ?? null),
+            self::floatOrNull($attributes['net_price'] ?? null),
+            self::floatOrNull($attributes['vat5_price'] ?? null),
+            self::floatOrNull($attributes['vat9_price'] ?? null),
+            self::floatOrNull($attributes['vat20_price'] ?? null),
+            self::floatOrNull($attributes['gross_price'] ?? null),
+            self::stringOrNull($attributes['bank_ref_number'] ?? null),
+            self::intOrNull($attributes['term_days'] ?? null),
+            self::floatOrNull($attributes['overdue_charge'] ?? null),
+            self::stringOrNull($attributes['notes'] ?? null),
+            self::intOrNull($attributes['base_document_files_id'] ?? null),
+            self::intOrNull($attributes['files_id'] ?? null),
+            self::boolOrNull($attributes['is_doubtful'] ?? null),
+            self::boolOrNull($attributes['is_hopeless'] ?? null),
+            self::boolOrNull($attributes['use_per_item_rounding'] ?? null),
+            self::boolOrNull($attributes['paid_in_cash'] ?? null),
+            self::intOrNull($attributes['cash_accounts_id'] ?? null),
+            self::intOrNull($attributes['cash_accounts_dimensions_id'] ?? null),
+            self::stringOrNull($attributes['invoice_info'] ?? null),
+            self::stringOrNull($attributes['payment_description'] ?? null),
+            self::stringOrNull($attributes['cl_currencies_id'] ?? null),
+            self::floatOrNull($attributes['currency_rate'] ?? null),
+            self::floatOrNull($attributes['base_gross_price'] ?? null),
+            self::floatOrNull($attributes['base_net_price'] ?? null),
+            self::floatOrNull($attributes['base_vat5_price'] ?? null),
+            self::floatOrNull($attributes['base_vat9_price'] ?? null),
+            self::floatOrNull($attributes['base_vat20_price'] ?? null),
+            self::stringOrNull($attributes['cash_payment_date'] ?? null),
+            self::boolOrNull($attributes['trade_secret'] ?? null),
+            self::intOrNull($attributes['receivable_accounts_id'] ?? null),
+            self::intOrNull($attributes['receivable_accounts_dimensions_id'] ?? null),
+            self::boolOrNull($attributes['intra_community_supply'] ?? null),
+            self::stringOrNull($attributes['client_vat_no'] ?? null),
+            self::boolOrNull($attributes['triangulation'] ?? null),
+            self::boolOrNull($attributes['assembled_in_member_state'] ?? null),
+            self::boolOrNull($attributes['show_client_balance'] ?? null),
+            self::intOrNull($attributes['subclients_id'] ?? null),
+            self::boolOrNull($attributes['is_xls_imported'] ?? null),
+            self::intOrNull($attributes['recipient_clients_id'] ?? null),
+            self::intOrNull($attributes['recipient_subclients_id'] ?? null),
+            self::stringOrNull($attributes['contract_number'] ?? null),
+            self::stringOrNull($attributes['invoice_content_code'] ?? null),
+            self::stringOrNull($attributes['invoice_content_text'] ?? null),
+            self::stringOrNull($attributes['period_start_date'] ?? null),
+            self::stringOrNull($attributes['period_end_date'] ?? null),
+            self::stringOrNull($attributes['additional_info_content'] ?? null),
+            self::intOrNull($attributes['bank_payment_orders_id'] ?? null),
+            self::intOrNull($attributes['bank_accounts_id'] ?? null),
+            self::stringOrNull($attributes['triangulation_seller_invoice_vat_no'] ?? null),
+            $items,
+            $deliveries,
+            self::intList($attributes['credit_invoices'] ?? null),
+            self::intList($attributes['journals'] ?? null),
+            self::intList($attributes['settlements'] ?? null),
+            self::intList($attributes['transactions'] ?? null),
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'credit_sale_invoices_id' => $this->creditSaleInvoicesId,
+            'credit_invoice_payment_type' => $this->creditInvoicePaymentType,
+            'sale_invoice_type' => $this->saleInvoiceType,
+            'cl_templates_id' => $this->clTemplatesId,
+            'clients_id' => $this->clientsId,
+            'client_name' => $this->clientName,
+            'cl_countries_id' => $this->clCountriesId,
+            'number_prefix' => $this->numberPrefix,
+            'number_suffix' => $this->numberSuffix,
+            'number' => $this->number,
+            'create_date' => $this->createDate,
+            'journal_date' => $this->journalDate,
+            'status' => $this->status,
+            'payment_status' => $this->paymentStatus,
+            'net_price' => $this->netPrice,
+            'vat5_price' => $this->vat5Price,
+            'vat9_price' => $this->vat9Price,
+            'vat20_price' => $this->vat20Price,
+            'gross_price' => $this->grossPrice,
+            'bank_ref_number' => $this->bankRefNumber,
+            'term_days' => $this->termDays,
+            'overdue_charge' => $this->overdueCharge,
+            'notes' => $this->notes,
+            'base_document_files_id' => $this->baseDocumentFilesId,
+            'files_id' => $this->filesId,
+            'is_doubtful' => $this->isDoubtful,
+            'is_hopeless' => $this->isHopeless,
+            'use_per_item_rounding' => $this->usePerItemRounding,
+            'paid_in_cash' => $this->paidInCash,
+            'cash_accounts_id' => $this->cashAccountsId,
+            'cash_accounts_dimensions_id' => $this->cashAccountsDimensionsId,
+            'invoice_info' => $this->invoiceInfo,
+            'payment_description' => $this->paymentDescription,
+            'cl_currencies_id' => $this->clCurrenciesId,
+            'currency_rate' => $this->currencyRate,
+            'base_gross_price' => $this->baseGrossPrice,
+            'base_net_price' => $this->baseNetPrice,
+            'base_vat5_price' => $this->baseVat5Price,
+            'base_vat9_price' => $this->baseVat9Price,
+            'base_vat20_price' => $this->baseVat20Price,
+            'cash_payment_date' => $this->cashPaymentDate,
+            'trade_secret' => $this->tradeSecret,
+            'receivable_accounts_id' => $this->receivableAccountsId,
+            'receivable_accounts_dimensions_id' => $this->receivableAccountsDimensionsId,
+            'intra_community_supply' => $this->intraCommunitySupply,
+            'client_vat_no' => $this->clientVatNo,
+            'triangulation' => $this->triangulation,
+            'assembled_in_member_state' => $this->assembledInMemberState,
+            'show_client_balance' => $this->showClientBalance,
+            'subclients_id' => $this->subclientsId,
+            'is_xls_imported' => $this->isXlsImported,
+            'recipient_clients_id' => $this->recipientClientsId,
+            'recipient_subclients_id' => $this->recipientSubclientsId,
+            'contract_number' => $this->contractNumber,
+            'invoice_content_code' => $this->invoiceContentCode,
+            'invoice_content_text' => $this->invoiceContentText,
+            'period_start_date' => $this->periodStartDate,
+            'period_end_date' => $this->periodEndDate,
+            'additional_info_content' => $this->additionalInfoContent,
+            'bank_payment_orders_id' => $this->bankPaymentOrdersId,
+            'bank_accounts_id' => $this->bankAccountsId,
+            'triangulation_seller_invoice_vat_no' => $this->triangulationSellerInvoiceVatNo,
+            'items' => array_map(
+                static fn (SaleInvoiceItemResponse $item): array => $item->toArray(),
+                $this->items,
+            ),
+            'deliveries' => array_map(
+                static fn (SaleInvoiceDeliveryResponse $delivery): array => $delivery->toArray(),
+                $this->deliveries,
+            ),
+            'credit_invoices' => $this->creditInvoices,
+            'journals' => $this->journals,
+            'settlements' => $this->settlements,
+            'transactions' => $this->transactions,
+        ];
+    }
+}

--- a/src/Testing/Responses/Fixtures/SalesInvoices/ListResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/SalesInvoices/ListResponseFixture.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Testing\Responses\Fixtures\SalesInvoices;
+
+final class ListResponseFixture
+{
+    /**
+     * @var array{current_page: int, total_pages: int, items: array<int, array<string, mixed>>}
+     */
+    public const ATTRIBUTES = [
+        'current_page' => 1,
+        'total_pages' => 1,
+        'items' => [
+            SaleInvoiceResponseFixture::ATTRIBUTES,
+        ],
+    ];
+}

--- a/src/Testing/Responses/Fixtures/SalesInvoices/SaleInvoiceDeliveryOptionsResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/SalesInvoices/SaleInvoiceDeliveryOptionsResponseFixture.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Testing\Responses\Fixtures\SalesInvoices;
+
+/**
+ * OpenAPI `SaleInvoicesDeliveryOptions` schema projection.
+ *
+ * @see https://rmp-api.rik.ee/openapi.yaml
+ */
+final class SaleInvoiceDeliveryOptionsResponseFixture
+{
+    /**
+     * @var array<string, mixed>
+     */
+    public const ATTRIBUTES = [
+        'can_send_einvoice' => false,
+        'can_send_einvoice_reason' => 'Missing e-invoice address',
+        'can_send_email' => true,
+        'can_send_email_addresses' => 'test@mail.ee',
+    ];
+}

--- a/src/Testing/Responses/Fixtures/SalesInvoices/SaleInvoiceDeliveryResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/SalesInvoices/SaleInvoiceDeliveryResponseFixture.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Testing\Responses\Fixtures\SalesInvoices;
+
+/**
+ * OpenAPI `SaleInvoicesDeliveries` schema projection.
+ *
+ * @see https://rmp-api.rik.ee/openapi.yaml
+ */
+final class SaleInvoiceDeliveryResponseFixture
+{
+    /**
+     * @var array<string, mixed>
+     */
+    public const ATTRIBUTES = [
+        'create_date' => '2016-02-16T10:00:00',
+        'destination_type' => 'EMAIL',
+        'invoice_type' => 'PDF',
+        'receiver_address' => 'test@mail.ee',
+        'receiver_name' => 'PAypal',
+        'send_method' => 1,
+        'sender_person_code' => null,
+        'sender_person_name' => null,
+        'status_date' => '2016-02-16T10:00:00',
+        'transfer_status_code' => 0,
+    ];
+}

--- a/src/Testing/Responses/Fixtures/SalesInvoices/SaleInvoiceItemResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/SalesInvoices/SaleInvoiceItemResponseFixture.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Testing\Responses\Fixtures\SalesInvoices;
+
+/**
+ * OpenAPI `SaleInvoicesItems` schema projection.
+ *
+ * @see https://rmp-api.rik.ee/openapi.yaml
+ */
+final class SaleInvoiceItemResponseFixture
+{
+    /**
+     * @var array<string, mixed>
+     */
+    public const ATTRIBUTES = [
+        'id' => 42,
+        'products_id' => 36166,
+        'cl_sale_articles_id' => 1,
+        'sale_accounts_id' => 3100,
+        'sale_accounts_dimensions_id' => null,
+        'amount' => 1.0,
+        'unit' => 'tk',
+        'unit_net_price' => 40608.0,
+        'total_net_price' => 40608.0,
+        'base_total_net_price' => 40608.0,
+        'vat_accounts_id' => null,
+        'vat_rate' => 20.0,
+        'discount_percent' => null,
+        'discount_amount' => null,
+        'custom_title' => 'Consulting',
+        'projects_project_id' => null,
+        'projects_location_id' => null,
+        'projects_person_id' => null,
+        'vat_amount' => 8121.6,
+    ];
+}

--- a/src/Testing/Responses/Fixtures/SalesInvoices/SaleInvoiceResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/SalesInvoices/SaleInvoiceResponseFixture.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Testing\Responses\Fixtures\SalesInvoices;
+
+/**
+ * OpenAPI `SaleInvoices` schema example (fuller projection).
+ *
+ * @see https://rmp-api.rik.ee/openapi.yaml
+ */
+final class SaleInvoiceResponseFixture
+{
+    /**
+     * @var array<string, mixed>
+     */
+    public const ATTRIBUTES = [
+        'id' => 1698,
+        'credit_sale_invoices_id' => null,
+        'credit_invoice_payment_type' => null,
+        'sale_invoice_type' => 'INVOICE',
+        'cl_templates_id' => 1,
+        'clients_id' => 126,
+        'client_name' => 'PAypal',
+        'cl_countries_id' => 'EST',
+        'number_prefix' => 'NX',
+        'number_suffix' => '91',
+        'number' => 'NX91',
+        'create_date' => '2016-02-15',
+        'journal_date' => '2016-02-15',
+        'status' => 'CONFIRMED',
+        'payment_status' => null,
+        'net_price' => 40608.0,
+        'vat5_price' => 0.0,
+        'vat9_price' => 0.0,
+        'vat20_price' => 8121.6,
+        'gross_price' => 48729.6,
+        'bank_ref_number' => '116758',
+        'term_days' => 30,
+        'overdue_charge' => 0.15,
+        'notes' => null,
+        'base_document_files_id' => null,
+        'files_id' => 3419,
+        'is_doubtful' => false,
+        'is_hopeless' => false,
+        'use_per_item_rounding' => false,
+        'paid_in_cash' => false,
+        'cash_accounts_id' => null,
+        'cash_accounts_dimensions_id' => null,
+        'invoice_info' => null,
+        'payment_description' => null,
+        'cl_currencies_id' => 'EUR',
+        'currency_rate' => 1.0,
+        'base_gross_price' => 48729.6,
+        'base_net_price' => 40608.0,
+        'base_vat5_price' => 0.0,
+        'base_vat9_price' => 0.0,
+        'base_vat20_price' => 8121.6,
+        'cash_payment_date' => null,
+        'trade_secret' => false,
+        'receivable_accounts_id' => 1210,
+        'receivable_accounts_dimensions_id' => null,
+        'intra_community_supply' => false,
+        'client_vat_no' => null,
+        'triangulation' => false,
+        'assembled_in_member_state' => false,
+        'show_client_balance' => false,
+        'subclients_id' => null,
+        'is_xls_imported' => false,
+        'recipient_clients_id' => null,
+        'recipient_subclients_id' => null,
+        'contract_number' => null,
+        'invoice_content_code' => null,
+        'invoice_content_text' => null,
+        'period_start_date' => null,
+        'period_end_date' => null,
+        'additional_info_content' => null,
+        'bank_payment_orders_id' => null,
+        'bank_accounts_id' => null,
+        'triangulation_seller_invoice_vat_no' => null,
+        'items' => [
+            SaleInvoiceItemResponseFixture::ATTRIBUTES,
+        ],
+        'deliveries' => [
+            SaleInvoiceDeliveryResponseFixture::ATTRIBUTES,
+        ],
+        'credit_invoices' => [],
+        'journals' => [],
+        'settlements' => [],
+        'transactions' => [],
+    ];
+}

--- a/tests/Client.php
+++ b/tests/Client.php
@@ -28,6 +28,11 @@ use EFinancialsClient\Responses\Products\ProductResponse;
 use EFinancialsClient\Responses\PurchaseInvoices\ListResponse as PurchaseInvoicesListResponse;
 use EFinancialsClient\Responses\PurchaseInvoices\PurchaseInvoiceItemResponse;
 use EFinancialsClient\Responses\PurchaseInvoices\PurchaseInvoiceResponse;
+use EFinancialsClient\Responses\SalesInvoices\ListResponse as SalesInvoicesListResponse;
+use EFinancialsClient\Responses\SalesInvoices\SaleInvoiceDeliveryOptionsResponse;
+use EFinancialsClient\Responses\SalesInvoices\SaleInvoiceDeliveryResponse;
+use EFinancialsClient\Responses\SalesInvoices\SaleInvoiceItemResponse;
+use EFinancialsClient\Responses\SalesInvoices\SaleInvoiceResponse;
 use EFinancialsClient\Responses\Transactions\ListResponse as TransactionsListResponse;
 use EFinancialsClient\Responses\Transactions\TransactionResponse;
 use EFinancialsClient\Testing\ClientFake;
@@ -39,6 +44,8 @@ use EFinancialsClient\Testing\Responses\Fixtures\Invoices\InvoiceSeriesResponseF
 use EFinancialsClient\Testing\Responses\Fixtures\Journals\JournalResponseFixture;
 use EFinancialsClient\Testing\Responses\Fixtures\Products\ProductResponseFixture;
 use EFinancialsClient\Testing\Responses\Fixtures\PurchaseInvoices\PurchaseInvoiceResponseFixture;
+use EFinancialsClient\Testing\Responses\Fixtures\SalesInvoices\SaleInvoiceDeliveryOptionsResponseFixture;
+use EFinancialsClient\Testing\Responses\Fixtures\SalesInvoices\SaleInvoiceResponseFixture;
 use EFinancialsClient\Testing\Responses\Fixtures\Transactions\TransactionResponseFixture;
 use EFinancialsClient\Transporters\HttpTransporter;
 use EFinancialsClient\ValueObjects\ApiCredentials;
@@ -73,9 +80,9 @@ it('returns decoded json from a successful request', function () {
         ApiCredentials::from('key-id', 'public-key', 'secret'),
     );
 
-    $client = new Client($transporter);
+    $response = $transporter->request(Payload::get('clients'));
 
-    expect($client->salesInvoices()->all())->toBe(['ok' => true]);
+    expect($response->data())->toBe(['ok' => true]);
 });
 
 it('throws a typed exception for http errors', function () {
@@ -88,8 +95,7 @@ it('throws a typed exception for http errors', function () {
         ApiCredentials::from('key-id', 'public-key', 'secret'),
     );
 
-    $client = new Client($transporter);
-    $client->salesInvoices()->all();
+    $transporter->request(Payload::get('clients'));
 })->throws(ErrorException::class, 'Unauthorized');
 
 it('exposes resource accessors', function () {
@@ -378,6 +384,54 @@ it('maps purchase invoices to a fuller OpenAPI projection', function () {
 
     $fake->assertSent('purchase_invoices', fn (Payload $payload): bool => $payload->method()->value === 'GET');
     $fake->assertSent('purchase_invoices/1983', fn (Payload $payload): bool => $payload->method()->value === 'GET');
+});
+
+it('maps sales invoices to a fuller OpenAPI projection', function () {
+    $fake = new ClientFake([
+        SalesInvoicesListResponse::fake(),
+        SaleInvoiceResponse::fake(),
+        SaleInvoiceDeliveryOptionsResponse::fake(),
+    ]);
+
+    $list = $fake->salesInvoices()->all();
+
+    expect($list)->toBeInstanceOf(SalesInvoicesListResponse::class)
+        ->and($list->items)->toHaveCount(1)
+        ->and($list->items[0])->toBeInstanceOf(SaleInvoiceResponse::class)
+        ->and($list->items[0]->id)->toBe(1698)
+        ->and($list->items[0]->number)->toBe('NX91')
+        ->and($list->items[0]->clientName)->toBe('PAypal')
+        ->and($list->items[0]->grossPrice)->toBe(48729.6)
+        ->and($list->items[0]->status)->toBe('CONFIRMED')
+        ->and($list->items[0]->items)->toHaveCount(1)
+        ->and($list->items[0]->items[0])->toBeInstanceOf(SaleInvoiceItemResponse::class)
+        ->and($list->items[0]->items[0]->customTitle)->toBe('Consulting')
+        ->and($list->items[0]->deliveries)->toHaveCount(1)
+        ->and($list->items[0]->deliveries[0])->toBeInstanceOf(SaleInvoiceDeliveryResponse::class)
+        ->and($list->items[0]->toArray())->toBe(
+            SaleInvoiceResponse::from(SaleInvoiceResponseFixture::ATTRIBUTES)->toArray()
+        );
+
+    $invoice = $fake->salesInvoices()->get(1698);
+
+    expect($invoice)->toBeInstanceOf(SaleInvoiceResponse::class)
+        ->and($invoice->bankRefNumber)->toBe('116758')
+        ->and($invoice->receivableAccountsId)->toBe(1210)
+        ->and($invoice->bankAccountsId)->toBeNull()
+        ->and($invoice->triangulationSellerInvoiceVatNo)->toBeNull();
+
+    $options = $fake->salesInvoices()->getDeliveryOptions(1698);
+
+    expect($options)->toBeInstanceOf(SaleInvoiceDeliveryOptionsResponse::class)
+        ->and($options->canSendEmail)->toBeTrue()
+        ->and($options->canSendEinvoice)->toBeFalse()
+        ->and($options->toArray())->toBe(
+            SaleInvoiceDeliveryOptionsResponse::from(SaleInvoiceDeliveryOptionsResponseFixture::ATTRIBUTES)->toArray()
+        );
+
+    $fake->assertSent('sale_invoices', fn (Payload $payload): bool => $payload->method()->value === 'GET');
+    $fake->assertSent('sale_invoices/1698', fn (Payload $payload): bool => $payload->method()->value === 'GET');
+    $fake->assertSent('sale_invoices/1698/delivery_options', fn (Payload $payload): bool => $payload->method()->value === 'GET');
 });
 
 it('builds a client through the factory facade', function () {

--- a/tests/Integration/DemoApi.php
+++ b/tests/Integration/DemoApi.php
@@ -13,6 +13,7 @@ use EFinancialsClient\Responses\Products\ListResponse as ProductsListResponse;
 use EFinancialsClient\Responses\PurchaseArticles\ListResponse as PurchaseArticlesListResponse;
 use EFinancialsClient\Responses\PurchaseInvoices\ListResponse as PurchaseInvoicesListResponse;
 use EFinancialsClient\Responses\SalesArticles\ListResponse as SalesArticlesListResponse;
+use EFinancialsClient\Responses\SalesInvoices\ListResponse as SalesInvoicesListResponse;
 use EFinancialsClient\Responses\Templates\ListResponse as TemplatesListResponse;
 use EFinancialsClient\Responses\Transactions\ListResponse as TransactionsListResponse;
 use EFinancialsClient\Responses\VatInfo\VatInfoResponse;
@@ -58,6 +59,6 @@ it('validates demo api response shapes', function () {
         ->and($client->invoices()->allSettings())->toBeInstanceOf(InvoiceInfoResponse::class)
         ->and($client->journals()->all())->toBeInstanceOf(JournalsListResponse::class)
         ->and($client->transactions()->all())->toBeInstanceOf(TransactionsListResponse::class)
-        ->and($client->salesInvoices()->all())->toBeArray()
+        ->and($client->salesInvoices()->all())->toBeInstanceOf(SalesInvoicesListResponse::class)
         ->and($client->purchaseInvoices()->all())->toBeInstanceOf(PurchaseInvoicesListResponse::class);
 })->skip(! $hasCredentials, 'Demo API credentials are not configured.');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds typed response DTOs for sales invoices (OpenAPI `SaleInvoices` / `SaleInvoicesItems` / `SaleInvoicesDeliveries` / `SaleInvoicesDeliveryOptions`), completing the planned fuller OpenAPI projection sequence after purchase invoices (#100).

## Changes

- `SaleInvoiceResponse` — full schema properties plus example-backed `bank_accounts_id` and `triangulation_seller_invoice_vat_no`
- Nested `SaleInvoiceItemResponse` and `SaleInvoiceDeliveryResponse`
- `SaleInvoiceDeliveryOptionsResponse` for delivery options
- Paginated `SalesInvoices\ListResponse`
- Fixtures under `Testing/Responses/Fixtures/SalesInvoices/`
- Resource + contract return typed DTOs / `ApiResponse` / `ApiFileResponse`
- Fixes `updateFile` to pass the request body to `Payload::put`
- HTTP decode smoke tests now exercise `HttpTransporter` directly (no remaining raw list resources)

## Test plan

- [x] `composer test` (Pint, PHPStan, type coverage, Pest)
- [x] Live demo integration assertion for sales invoices list shape
- [ ] CI green
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc292-2ac0-79d0-9014-6126f82761ad?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc292-2ac0-79d0-9014-6126f82761ad&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

