### PR TITLE
refactor: add ResourcePath helpers for Payload resource paths

### DIFF
--- a/src/Resources/AccountDimensions.php
+++ b/src/Resources/AccountDimensions.php
@@ -8,6 +8,7 @@ use EFinancialsClient\Contracts\Resources\AccountDimensionsContract;
 use EFinancialsClient\Resources\Concerns\Transportable;
 use EFinancialsClient\Responses\AccountDimensions\ListResponse;
 use EFinancialsClient\ValueObjects\Transporter\Payload;
+use EFinancialsClient\ValueObjects\Transporter\ResourcePath;
 use EFinancialsClient\ValueObjects\Transporter\Response;
 
 final class AccountDimensions implements AccountDimensionsContract
@@ -21,7 +22,7 @@ final class AccountDimensions implements AccountDimensionsContract
      */
     public function all(): ListResponse
     {
-        $payload = Payload::get('account_dimensions');
+        $payload = Payload::get(ResourcePath::collection('account_dimensions'));
 
         /** @var Response<array<int, array<array-key, mixed>>> $response */
         $response = $this->transporter->request($payload);

--- a/src/Resources/Accounts.php
+++ b/src/Resources/Accounts.php
@@ -8,6 +8,7 @@ use EFinancialsClient\Contracts\Resources\AccountsContract;
 use EFinancialsClient\Resources\Concerns\Transportable;
 use EFinancialsClient\Responses\Accounts\ListResponse;
 use EFinancialsClient\ValueObjects\Transporter\Payload;
+use EFinancialsClient\ValueObjects\Transporter\ResourcePath;
 use EFinancialsClient\ValueObjects\Transporter\Response;
 
 final class Accounts implements AccountsContract
@@ -21,7 +22,7 @@ final class Accounts implements AccountsContract
      */
     public function all(): ListResponse
     {
-        $payload = Payload::get('accounts');
+        $payload = Payload::get(ResourcePath::collection('accounts'));
 
         /** @var Response<array<int, array<array-key, mixed>>> $response */
         $response = $this->transporter->request($payload);

--- a/src/Resources/Bank.php
+++ b/src/Resources/Bank.php
@@ -11,6 +11,7 @@ use EFinancialsClient\Responses\Bank\BankAccountResponse;
 use EFinancialsClient\Responses\Bank\ListResponse;
 use EFinancialsClient\Responses\VatInfo\VatInfoResponse;
 use EFinancialsClient\ValueObjects\Transporter\Payload;
+use EFinancialsClient\ValueObjects\Transporter\ResourcePath;
 use EFinancialsClient\ValueObjects\Transporter\Response;
 use InvalidArgumentException;
 
@@ -25,7 +26,7 @@ final class Bank implements BankContract
      */
     public function all(): ListResponse
     {
-        $payload = Payload::get('bank_accounts');
+        $payload = Payload::get(ResourcePath::collection('bank_accounts'));
 
         /** @var Response<array<int, array<array-key, mixed>>> $response */
         $response = $this->transporter->request($payload);
@@ -43,7 +44,7 @@ final class Bank implements BankContract
      */
     public function get(int $id): BankAccountResponse
     {
-        $payload = Payload::get('bank_accounts/'.$id);
+        $payload = Payload::get(ResourcePath::one('bank_accounts', $id));
 
         /** @var Response<array<array-key, mixed>> $response */
         $response = $this->transporter->request($payload);
@@ -78,7 +79,7 @@ final class Bank implements BankContract
             );
         }
 
-        $payload = Payload::post('bank_accounts', $parameters);
+        $payload = Payload::post(ResourcePath::collection('bank_accounts'), $parameters);
 
         /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
@@ -113,7 +114,7 @@ final class Bank implements BankContract
             );
         }
 
-        $payload = Payload::patch('bank_accounts/'.$id, $parameters);
+        $payload = Payload::patch(ResourcePath::one('bank_accounts', $id), $parameters);
 
         /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
@@ -130,7 +131,7 @@ final class Bank implements BankContract
      */
     public function delete(int $id): ApiResponse
     {
-        $payload = Payload::delete('bank_accounts/'.$id);
+        $payload = Payload::delete(ResourcePath::one('bank_accounts', $id));
 
         /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
@@ -145,7 +146,7 @@ final class Bank implements BankContract
      */
     public function getVatInfo(): VatInfoResponse
     {
-        $payload = Payload::get('vat_info');
+        $payload = Payload::get(ResourcePath::collection('vat_info'));
 
         /** @var Response<array{vat_number?: string|null, tax_refnumber?: string|null}> $response */
         $response = $this->transporter->request($payload);

--- a/src/Resources/Clients.php
+++ b/src/Resources/Clients.php
@@ -12,6 +12,7 @@ use EFinancialsClient\Responses\ApiResponse;
 use EFinancialsClient\Responses\Clients\ClientResponse;
 use EFinancialsClient\Responses\Clients\ListResponse;
 use EFinancialsClient\ValueObjects\Transporter\Payload;
+use EFinancialsClient\ValueObjects\Transporter\ResourcePath;
 use EFinancialsClient\ValueObjects\Transporter\Response;
 use InvalidArgumentException;
 
@@ -41,7 +42,7 @@ final class Clients implements ClientsContract
                 : $modifiedSince;
         }
 
-        $payload = Payload::get('clients', $query);
+        $payload = Payload::get(ResourcePath::collection('clients'), $query);
 
         /** @var Response<array{current_page: int, total_pages: int, items: array<int, array<string, mixed>>}> $response */
         $response = $this->transporter->request($payload);
@@ -58,7 +59,7 @@ final class Clients implements ClientsContract
      */
     public function get(int $id): ClientResponse
     {
-        $payload = Payload::get('clients/'.$id);
+        $payload = Payload::get(ResourcePath::one('clients', $id));
 
         /** @var Response<array<string, mixed>> $response */
         $response = $this->transporter->request($payload);
@@ -98,7 +99,7 @@ final class Clients implements ClientsContract
             );
         }
 
-        $payload = Payload::post('clients', $parameters);
+        $payload = Payload::post(ResourcePath::collection('clients'), $parameters);
 
         /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
@@ -139,7 +140,7 @@ final class Clients implements ClientsContract
             );
         }
 
-        $payload = Payload::patch('clients/'.$id, $parameters);
+        $payload = Payload::patch(ResourcePath::one('clients', $id), $parameters);
 
         /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
@@ -156,7 +157,7 @@ final class Clients implements ClientsContract
      */
     public function delete(int $id): ApiResponse
     {
-        $payload = Payload::delete('clients/'.$id);
+        $payload = Payload::delete(ResourcePath::one('clients', $id));
 
         /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
@@ -173,7 +174,7 @@ final class Clients implements ClientsContract
      */
     public function deactivate(int $id): ApiResponse
     {
-        $payload = Payload::patch('clients/'.$id.'/deactivate');
+        $payload = Payload::patch(ResourcePath::one('clients', $id, 'deactivate'));
 
         /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
@@ -190,7 +191,7 @@ final class Clients implements ClientsContract
      */
     public function reactivate(int $id): ApiResponse
     {
-        $payload = Payload::patch('clients/'.$id.'/reactivate');
+        $payload = Payload::patch(ResourcePath::one('clients', $id, 'reactivate'));
 
         /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);

--- a/src/Resources/CostProfitCentres.php
+++ b/src/Resources/CostProfitCentres.php
@@ -10,6 +10,7 @@ use EFinancialsClient\Contracts\Resources\CostProfitCentresContract;
 use EFinancialsClient\Resources\Concerns\Transportable;
 use EFinancialsClient\Responses\CostProfitCentres\ListResponse;
 use EFinancialsClient\ValueObjects\Transporter\Payload;
+use EFinancialsClient\ValueObjects\Transporter\ResourcePath;
 use EFinancialsClient\ValueObjects\Transporter\Response;
 
 final class CostProfitCentres implements CostProfitCentresContract
@@ -38,7 +39,7 @@ final class CostProfitCentres implements CostProfitCentresContract
                 : $modifiedSince;
         }
 
-        $payload = Payload::get('projects', $query);
+        $payload = Payload::get(ResourcePath::collection('projects'), $query);
 
         /** @var Response<array{current_page: int, total_pages: int, items: array<int, array<array-key, mixed>>}> $response */
         $response = $this->transporter->request($payload);

--- a/src/Resources/Currencies.php
+++ b/src/Resources/Currencies.php
@@ -8,6 +8,7 @@ use EFinancialsClient\Contracts\Resources\CurrenciesContract;
 use EFinancialsClient\Resources\Concerns\Transportable;
 use EFinancialsClient\Responses\Currencies\ListResponse;
 use EFinancialsClient\ValueObjects\Transporter\Payload;
+use EFinancialsClient\ValueObjects\Transporter\ResourcePath;
 use EFinancialsClient\ValueObjects\Transporter\Response;
 
 final class Currencies implements CurrenciesContract
@@ -21,7 +22,7 @@ final class Currencies implements CurrenciesContract
      */
     public function all(): ListResponse
     {
-        $payload = Payload::get('currencies');
+        $payload = Payload::get(ResourcePath::collection('currencies'));
 
         /** @var Response<array<int, array{id: string, name_est?: string|null, name_eng?: string|null}>> $response */
         $response = $this->transporter->request($payload);

--- a/src/Resources/Invoices.php
+++ b/src/Resources/Invoices.php
@@ -11,6 +11,7 @@ use EFinancialsClient\Responses\Invoices\InvoiceInfoResponse;
 use EFinancialsClient\Responses\Invoices\InvoiceSeriesResponse;
 use EFinancialsClient\Responses\Invoices\ListResponse;
 use EFinancialsClient\ValueObjects\Transporter\Payload;
+use EFinancialsClient\ValueObjects\Transporter\ResourcePath;
 use EFinancialsClient\ValueObjects\Transporter\Response;
 use InvalidArgumentException;
 
@@ -25,7 +26,7 @@ final class Invoices implements InvoicesContract
      */
     public function all(): ListResponse
     {
-        $payload = Payload::get('invoice_series');
+        $payload = Payload::get(ResourcePath::collection('invoice_series'));
 
         /** @var Response<array<int, array<array-key, mixed>>> $response */
         $response = $this->transporter->request($payload);
@@ -43,7 +44,7 @@ final class Invoices implements InvoicesContract
      */
     public function get(int $id): InvoiceSeriesResponse
     {
-        $payload = Payload::get('invoice_series/'.$id);
+        $payload = Payload::get(ResourcePath::one('invoice_series', $id));
 
         /** @var Response<array<array-key, mixed>> $response */
         $response = $this->transporter->request($payload);
@@ -81,7 +82,7 @@ final class Invoices implements InvoicesContract
             );
         }
 
-        $payload = Payload::post('invoice_series', $parameters);
+        $payload = Payload::post(ResourcePath::collection('invoice_series'), $parameters);
 
         /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
@@ -119,7 +120,7 @@ final class Invoices implements InvoicesContract
             );
         }
 
-        $payload = Payload::patch('invoice_series/'.$id, $parameters);
+        $payload = Payload::patch(ResourcePath::one('invoice_series', $id), $parameters);
 
         /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
@@ -136,7 +137,7 @@ final class Invoices implements InvoicesContract
      */
     public function delete(int $id): ApiResponse
     {
-        $payload = Payload::delete('invoice_series/'.$id);
+        $payload = Payload::delete(ResourcePath::one('invoice_series', $id));
 
         /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
@@ -151,7 +152,7 @@ final class Invoices implements InvoicesContract
      */
     public function allSettings(): InvoiceInfoResponse
     {
-        $payload = Payload::get('invoice_info');
+        $payload = Payload::get(ResourcePath::collection('invoice_info'));
 
         /** @var Response<array<array-key, mixed>> $response */
         $response = $this->transporter->request($payload);
@@ -168,7 +169,7 @@ final class Invoices implements InvoicesContract
      */
     public function updateSettings(array $parameters): ApiResponse
     {
-        $payload = Payload::patch('invoice_info', $parameters);
+        $payload = Payload::patch(ResourcePath::collection('invoice_info'), $parameters);
 
         /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);

--- a/src/Resources/Journals.php
+++ b/src/Resources/Journals.php
@@ -13,6 +13,7 @@ use EFinancialsClient\Responses\ApiResponse;
 use EFinancialsClient\Responses\Journals\JournalResponse;
 use EFinancialsClient\Responses\Journals\ListResponse;
 use EFinancialsClient\ValueObjects\Transporter\Payload;
+use EFinancialsClient\ValueObjects\Transporter\ResourcePath;
 use EFinancialsClient\ValueObjects\Transporter\Response;
 use InvalidArgumentException;
 
@@ -60,7 +61,7 @@ final class Journals implements JournalsContract
                 : $endDate;
         }
 
-        $payload = Payload::get('journals', $query);
+        $payload = Payload::get(ResourcePath::collection('journals'), $query);
 
         /** @var Response<array{current_page: int, total_pages: int, items: array<int, array<string, mixed>>}> $response */
         $response = $this->transporter->request($payload);
@@ -77,7 +78,7 @@ final class Journals implements JournalsContract
      */
     public function get(int $id): JournalResponse
     {
-        $payload = Payload::get('journals/'.$id);
+        $payload = Payload::get(ResourcePath::one('journals', $id));
 
         /** @var Response<array<string, mixed>> $response */
         $response = $this->transporter->request($payload);
@@ -112,7 +113,7 @@ final class Journals implements JournalsContract
             );
         }
 
-        $payload = Payload::post('journals', $parameters);
+        $payload = Payload::post(ResourcePath::collection('journals'), $parameters);
 
         /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
@@ -148,7 +149,7 @@ final class Journals implements JournalsContract
             );
         }
 
-        $payload = Payload::patch('journals/'.$id, $parameters);
+        $payload = Payload::patch(ResourcePath::one('journals', $id), $parameters);
 
         /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
@@ -165,7 +166,7 @@ final class Journals implements JournalsContract
      */
     public function delete(int $id): ApiResponse
     {
-        $payload = Payload::delete('journals/'.$id);
+        $payload = Payload::delete(ResourcePath::one('journals', $id));
 
         /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
@@ -182,7 +183,7 @@ final class Journals implements JournalsContract
      */
     public function register(int $id): ApiResponse
     {
-        $payload = Payload::patch('journals/'.$id.'/register');
+        $payload = Payload::patch(ResourcePath::one('journals', $id, 'register'));
 
         /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
@@ -199,7 +200,7 @@ final class Journals implements JournalsContract
      */
     public function invalidate(int $id): ApiResponse
     {
-        $payload = Payload::patch('journals/'.$id.'/invalidate');
+        $payload = Payload::patch(ResourcePath::one('journals', $id, 'invalidate'));
 
         /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
@@ -216,7 +217,7 @@ final class Journals implements JournalsContract
      */
     public function getFile(int $id): ApiFileResponse
     {
-        $payload = Payload::get('journals/'.$id.'/document_user');
+        $payload = Payload::get(ResourcePath::one('journals', $id, 'document_user'));
 
         /** @var Response<array{name: string, contents: string}> $response */
         $response = $this->transporter->request($payload);
@@ -252,7 +253,7 @@ final class Journals implements JournalsContract
             );
         }
 
-        $payload = Payload::put('journals/'.$id.'/document_user', $parameters);
+        $payload = Payload::put(ResourcePath::one('journals', $id, 'document_user'), $parameters);
 
         /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
@@ -269,7 +270,7 @@ final class Journals implements JournalsContract
      */
     public function deleteFile(int $id): ApiResponse
     {
-        $payload = Payload::delete('journals/'.$id.'/document_user');
+        $payload = Payload::delete(ResourcePath::one('journals', $id, 'document_user'));
 
         /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);

--- a/src/Resources/Products.php
+++ b/src/Resources/Products.php
@@ -12,6 +12,7 @@ use EFinancialsClient\Responses\ApiResponse;
 use EFinancialsClient\Responses\Products\ListResponse;
 use EFinancialsClient\Responses\Products\ProductResponse;
 use EFinancialsClient\ValueObjects\Transporter\Payload;
+use EFinancialsClient\ValueObjects\Transporter\ResourcePath;
 use EFinancialsClient\ValueObjects\Transporter\Response;
 use InvalidArgumentException;
 
@@ -41,7 +42,7 @@ final class Products implements ProductsContract
                 : $modifiedSince;
         }
 
-        $payload = Payload::get('products', $query);
+        $payload = Payload::get(ResourcePath::collection('products'), $query);
 
         /** @var Response<array{current_page: int, total_pages: int, items: array<int, array<string, mixed>>}> $response */
         $response = $this->transporter->request($payload);
@@ -58,7 +59,7 @@ final class Products implements ProductsContract
      */
     public function get(int $id): ProductResponse
     {
-        $payload = Payload::get('products/'.$id);
+        $payload = Payload::get(ResourcePath::one('products', $id));
 
         /** @var Response<array<string, mixed>> $response */
         $response = $this->transporter->request($payload);
@@ -75,7 +76,7 @@ final class Products implements ProductsContract
      */
     public function create(string $name, string $code, array $parameters = []): ApiResponse
     {
-        $payload = Payload::post('products', array_merge([
+        $payload = Payload::post(ResourcePath::collection('products'), array_merge([
             'name' => $name,
             'code' => $code,
         ], $parameters));
@@ -114,7 +115,7 @@ final class Products implements ProductsContract
             );
         }
 
-        $payload = Payload::patch('products/'.$id, $parameters);
+        $payload = Payload::patch(ResourcePath::one('products', $id), $parameters);
 
         /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
@@ -131,7 +132,7 @@ final class Products implements ProductsContract
      */
     public function delete(int $id): ApiResponse
     {
-        $payload = Payload::delete('products/'.$id);
+        $payload = Payload::delete(ResourcePath::one('products', $id));
 
         /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
@@ -148,7 +149,7 @@ final class Products implements ProductsContract
      */
     public function deactivate(int $id): ApiResponse
     {
-        $payload = Payload::patch('products/'.$id.'/deactivate');
+        $payload = Payload::patch(ResourcePath::one('products', $id, 'deactivate'));
 
         /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
@@ -165,7 +166,7 @@ final class Products implements ProductsContract
      */
     public function reactivate(int $id): ApiResponse
     {
-        $payload = Payload::patch('products/'.$id.'/reactivate');
+        $payload = Payload::patch(ResourcePath::one('products', $id, 'reactivate'));
 
         /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);

--- a/src/Resources/PurchaseArticles.php
+++ b/src/Resources/PurchaseArticles.php
@@ -8,6 +8,7 @@ use EFinancialsClient\Contracts\Resources\PurchaseArticlesContract;
 use EFinancialsClient\Resources\Concerns\Transportable;
 use EFinancialsClient\Responses\PurchaseArticles\ListResponse;
 use EFinancialsClient\ValueObjects\Transporter\Payload;
+use EFinancialsClient\ValueObjects\Transporter\ResourcePath;
 use EFinancialsClient\ValueObjects\Transporter\Response;
 
 final class PurchaseArticles implements PurchaseArticlesContract
@@ -21,7 +22,7 @@ final class PurchaseArticles implements PurchaseArticlesContract
      */
     public function all(): ListResponse
     {
-        $payload = Payload::get('purchase_articles');
+        $payload = Payload::get(ResourcePath::collection('purchase_articles'));
 
         /** @var Response<array<int, array<array-key, mixed>>> $response */
         $response = $this->transporter->request($payload);

--- a/src/Resources/PurchaseInvoices.php
+++ b/src/Resources/PurchaseInvoices.php
@@ -13,6 +13,7 @@ use EFinancialsClient\Responses\ApiResponse;
 use EFinancialsClient\Responses\PurchaseInvoices\ListResponse;
 use EFinancialsClient\Responses\PurchaseInvoices\PurchaseInvoiceResponse;
 use EFinancialsClient\ValueObjects\Transporter\Payload;
+use EFinancialsClient\ValueObjects\Transporter\ResourcePath;
 use EFinancialsClient\ValueObjects\Transporter\Response;
 use InvalidArgumentException;
 
@@ -78,7 +79,7 @@ final class PurchaseInvoices implements PurchaseInvoicesContract
             $query['clients_id'] = $clientsId;
         }
 
-        $payload = Payload::get('purchase_invoices', $query);
+        $payload = Payload::get(ResourcePath::collection('purchase_invoices'), $query);
 
         /** @var Response<array{current_page: int, total_pages: int, items: array<int, array<string, mixed>>}> $response */
         $response = $this->transporter->request($payload);
@@ -95,7 +96,7 @@ final class PurchaseInvoices implements PurchaseInvoicesContract
      */
     public function get(int $id): PurchaseInvoiceResponse
     {
-        $payload = Payload::get('purchase_invoices/'.$id);
+        $payload = Payload::get(ResourcePath::one('purchase_invoices', $id));
 
         /** @var Response<array<string, mixed>> $response */
         $response = $this->transporter->request($payload);
@@ -135,7 +136,7 @@ final class PurchaseInvoices implements PurchaseInvoicesContract
             );
         }
 
-        $payload = Payload::post('purchase_invoices', $parameters);
+        $payload = Payload::post(ResourcePath::collection('purchase_invoices'), $parameters);
 
         /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
@@ -176,7 +177,7 @@ final class PurchaseInvoices implements PurchaseInvoicesContract
             );
         }
 
-        $payload = Payload::patch('purchase_invoices/'.$id, $parameters);
+        $payload = Payload::patch(ResourcePath::one('purchase_invoices', $id), $parameters);
 
         /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
@@ -193,7 +194,7 @@ final class PurchaseInvoices implements PurchaseInvoicesContract
      */
     public function delete(int $id): ApiResponse
     {
-        $payload = Payload::delete('purchase_invoices/'.$id);
+        $payload = Payload::delete(ResourcePath::one('purchase_invoices', $id));
 
         /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
@@ -210,7 +211,7 @@ final class PurchaseInvoices implements PurchaseInvoicesContract
      */
     public function register(int $id): ApiResponse
     {
-        $payload = Payload::patch('purchase_invoices/'.$id.'/register');
+        $payload = Payload::patch(ResourcePath::one('purchase_invoices', $id, 'register'));
 
         /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
@@ -227,7 +228,7 @@ final class PurchaseInvoices implements PurchaseInvoicesContract
      */
     public function invalidate(int $id): ApiResponse
     {
-        $payload = Payload::patch('purchase_invoices/'.$id.'/invalidate');
+        $payload = Payload::patch(ResourcePath::one('purchase_invoices', $id, 'invalidate'));
 
         /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
@@ -244,7 +245,7 @@ final class PurchaseInvoices implements PurchaseInvoicesContract
      */
     public function getFile(int $id): ApiFileResponse
     {
-        $payload = Payload::get('purchase_invoices/'.$id.'/document_user');
+        $payload = Payload::get(ResourcePath::one('purchase_invoices', $id, 'document_user'));
 
         /** @var Response<array{name: string, contents: string}> $response */
         $response = $this->transporter->request($payload);
@@ -280,7 +281,7 @@ final class PurchaseInvoices implements PurchaseInvoicesContract
             );
         }
 
-        $payload = Payload::put('purchase_invoices/'.$id.'/document_user', $parameters);
+        $payload = Payload::put(ResourcePath::one('purchase_invoices', $id, 'document_user'), $parameters);
 
         /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
@@ -297,7 +298,7 @@ final class PurchaseInvoices implements PurchaseInvoicesContract
      */
     public function deleteFile(int $id): ApiResponse
     {
-        $payload = Payload::delete('purchase_invoices/'.$id.'/document_user');
+        $payload = Payload::delete(ResourcePath::one('purchase_invoices', $id, 'document_user'));
 
         /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);

--- a/src/Resources/SalesArticles.php
+++ b/src/Resources/SalesArticles.php
@@ -8,6 +8,7 @@ use EFinancialsClient\Contracts\Resources\SalesArticlesContract;
 use EFinancialsClient\Resources\Concerns\Transportable;
 use EFinancialsClient\Responses\SalesArticles\ListResponse;
 use EFinancialsClient\ValueObjects\Transporter\Payload;
+use EFinancialsClient\ValueObjects\Transporter\ResourcePath;
 use EFinancialsClient\ValueObjects\Transporter\Response;
 
 final class SalesArticles implements SalesArticlesContract
@@ -21,7 +22,7 @@ final class SalesArticles implements SalesArticlesContract
      */
     public function all(): ListResponse
     {
-        $payload = Payload::get('sale_articles');
+        $payload = Payload::get(ResourcePath::collection('sale_articles'));
 
         /** @var Response<array<int, array<array-key, mixed>>> $response */
         $response = $this->transporter->request($payload);

--- a/src/Resources/SalesInvoices.php
+++ b/src/Resources/SalesInvoices.php
@@ -14,6 +14,7 @@ use EFinancialsClient\Responses\SalesInvoices\ListResponse;
 use EFinancialsClient\Responses\SalesInvoices\SaleInvoiceDeliveryOptionsResponse;
 use EFinancialsClient\Responses\SalesInvoices\SaleInvoiceResponse;
 use EFinancialsClient\ValueObjects\Transporter\Payload;
+use EFinancialsClient\ValueObjects\Transporter\ResourcePath;
 use EFinancialsClient\ValueObjects\Transporter\Response;
 use InvalidArgumentException;
 
@@ -79,7 +80,7 @@ final class SalesInvoices implements SalesInvoicesContract
             $query['clients_id'] = $clientsId;
         }
 
-        $payload = Payload::get('sale_invoices', $query);
+        $payload = Payload::get(ResourcePath::collection('sale_invoices'), $query);
 
         /** @var Response<array{current_page: int, total_pages: int, items: array<int, array<string, mixed>>}> $response */
         $response = $this->transporter->request($payload);
@@ -96,7 +97,7 @@ final class SalesInvoices implements SalesInvoicesContract
      */
     public function get(int $id): SaleInvoiceResponse
     {
-        $payload = Payload::get('sale_invoices/'.$id);
+        $payload = Payload::get(ResourcePath::one('sale_invoices', $id));
 
         /** @var Response<array<string, mixed>> $response */
         $response = $this->transporter->request($payload);
@@ -139,7 +140,7 @@ final class SalesInvoices implements SalesInvoicesContract
             );
         }
 
-        $payload = Payload::post('sale_invoices', $parameters);
+        $payload = Payload::post(ResourcePath::collection('sale_invoices'), $parameters);
 
         /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
@@ -183,7 +184,7 @@ final class SalesInvoices implements SalesInvoicesContract
             );
         }
 
-        $payload = Payload::patch('sale_invoices/'.$id, $parameters);
+        $payload = Payload::patch(ResourcePath::one('sale_invoices', $id), $parameters);
 
         /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
@@ -200,7 +201,7 @@ final class SalesInvoices implements SalesInvoicesContract
      */
     public function delete(int $id): ApiResponse
     {
-        $payload = Payload::delete('sale_invoices/'.$id);
+        $payload = Payload::delete(ResourcePath::one('sale_invoices', $id));
 
         /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
@@ -217,7 +218,7 @@ final class SalesInvoices implements SalesInvoicesContract
      */
     public function register(int $id): ApiResponse
     {
-        $payload = Payload::patch('sale_invoices/'.$id.'/register');
+        $payload = Payload::patch(ResourcePath::one('sale_invoices', $id, 'register'));
 
         /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
@@ -234,7 +235,7 @@ final class SalesInvoices implements SalesInvoicesContract
      */
     public function invalidate(int $id): ApiResponse
     {
-        $payload = Payload::patch('sale_invoices/'.$id.'/invalidate');
+        $payload = Payload::patch(ResourcePath::one('sale_invoices', $id, 'invalidate'));
 
         /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
@@ -251,7 +252,7 @@ final class SalesInvoices implements SalesInvoicesContract
      */
     public function getXml(int $id): ApiFileResponse
     {
-        $payload = Payload::get('sale_invoices/'.$id.'/xml');
+        $payload = Payload::get(ResourcePath::one('sale_invoices', $id, 'xml'));
 
         /** @var Response<array{name: string, contents: string}> $response */
         $response = $this->transporter->request($payload);
@@ -268,7 +269,7 @@ final class SalesInvoices implements SalesInvoicesContract
      */
     public function getSystemPdf(int $id): ApiFileResponse
     {
-        $payload = Payload::get('sale_invoices/'.$id.'/pdf_system');
+        $payload = Payload::get(ResourcePath::one('sale_invoices', $id, 'pdf_system'));
 
         /** @var Response<array{name: string, contents: string}> $response */
         $response = $this->transporter->request($payload);
@@ -285,7 +286,7 @@ final class SalesInvoices implements SalesInvoicesContract
      */
     public function getFile(int $id): ApiFileResponse
     {
-        $payload = Payload::get('sale_invoices/'.$id.'/document_user');
+        $payload = Payload::get(ResourcePath::one('sale_invoices', $id, 'document_user'));
 
         /** @var Response<array{name: string, contents: string}> $response */
         $response = $this->transporter->request($payload);
@@ -321,7 +322,7 @@ final class SalesInvoices implements SalesInvoicesContract
             );
         }
 
-        $payload = Payload::put('sale_invoices/'.$id.'/document_user', $parameters);
+        $payload = Payload::put(ResourcePath::one('sale_invoices', $id, 'document_user'), $parameters);
 
         /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
@@ -338,7 +339,7 @@ final class SalesInvoices implements SalesInvoicesContract
      */
     public function deleteFile(int $id): ApiResponse
     {
-        $payload = Payload::delete('sale_invoices/'.$id.'/document_user');
+        $payload = Payload::delete(ResourcePath::one('sale_invoices', $id, 'document_user'));
 
         /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
@@ -355,7 +356,7 @@ final class SalesInvoices implements SalesInvoicesContract
      */
     public function getDeliveryOptions(int $id): SaleInvoiceDeliveryOptionsResponse
     {
-        $payload = Payload::get('sale_invoices/'.$id.'/delivery_options');
+        $payload = Payload::get(ResourcePath::one('sale_invoices', $id, 'delivery_options'));
 
         /** @var Response<array<string, mixed>> $response */
         $response = $this->transporter->request($payload);
@@ -391,7 +392,7 @@ final class SalesInvoices implements SalesInvoicesContract
             );
         }
 
-        $payload = Payload::patch('sale_invoices/'.$id.'/deliver', $parameters);
+        $payload = Payload::patch(ResourcePath::one('sale_invoices', $id, 'deliver'), $parameters);
 
         /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);

--- a/src/Resources/Templates.php
+++ b/src/Resources/Templates.php
@@ -8,6 +8,7 @@ use EFinancialsClient\Contracts\Resources\TemplatesContract;
 use EFinancialsClient\Resources\Concerns\Transportable;
 use EFinancialsClient\Responses\Templates\ListResponse;
 use EFinancialsClient\ValueObjects\Transporter\Payload;
+use EFinancialsClient\ValueObjects\Transporter\ResourcePath;
 use EFinancialsClient\ValueObjects\Transporter\Response;
 
 final class Templates implements TemplatesContract
@@ -21,7 +22,7 @@ final class Templates implements TemplatesContract
      */
     public function all(): ListResponse
     {
-        $payload = Payload::get('templates');
+        $payload = Payload::get(ResourcePath::collection('templates'));
 
         /** @var Response<array<int, array{id: int, name: string, is_default?: bool, cl_languages_id?: string|null}>> $response */
         $response = $this->transporter->request($payload);

--- a/src/Resources/Transactions.php
+++ b/src/Resources/Transactions.php
@@ -13,6 +13,7 @@ use EFinancialsClient\Responses\ApiResponse;
 use EFinancialsClient\Responses\Transactions\ListResponse;
 use EFinancialsClient\Responses\Transactions\TransactionResponse;
 use EFinancialsClient\ValueObjects\Transporter\Payload;
+use EFinancialsClient\ValueObjects\Transporter\ResourcePath;
 use EFinancialsClient\ValueObjects\Transporter\Response;
 use InvalidArgumentException;
 
@@ -78,7 +79,7 @@ final class Transactions implements TransactionsContract
             $query['clients_id'] = $clientsId;
         }
 
-        $payload = Payload::get('transactions', $query);
+        $payload = Payload::get(ResourcePath::collection('transactions'), $query);
 
         /** @var Response<array{current_page: int, total_pages: int, items: array<int, array<string, mixed>>}> $response */
         $response = $this->transporter->request($payload);
@@ -95,7 +96,7 @@ final class Transactions implements TransactionsContract
      */
     public function get(int $id): TransactionResponse
     {
-        $payload = Payload::get('transactions/'.$id);
+        $payload = Payload::get(ResourcePath::one('transactions', $id));
 
         /** @var Response<array<string, mixed>> $response */
         $response = $this->transporter->request($payload);
@@ -133,7 +134,7 @@ final class Transactions implements TransactionsContract
             );
         }
 
-        $payload = Payload::post('transactions', $parameters);
+        $payload = Payload::post(ResourcePath::collection('transactions'), $parameters);
 
         /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
@@ -172,7 +173,7 @@ final class Transactions implements TransactionsContract
             );
         }
 
-        $payload = Payload::patch('transactions/'.$id, $parameters);
+        $payload = Payload::patch(ResourcePath::one('transactions', $id), $parameters);
 
         /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
@@ -189,7 +190,7 @@ final class Transactions implements TransactionsContract
      */
     public function delete(int $id): ApiResponse
     {
-        $payload = Payload::delete('transactions/'.$id);
+        $payload = Payload::delete(ResourcePath::one('transactions', $id));
 
         /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
@@ -207,7 +208,7 @@ final class Transactions implements TransactionsContract
      */
     public function register(int $id, array $distributions = []): ApiResponse
     {
-        $payload = Payload::patch('transactions/'.$id.'/register', $distributions);
+        $payload = Payload::patch(ResourcePath::one('transactions', $id, 'register'), $distributions);
 
         /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
@@ -224,7 +225,7 @@ final class Transactions implements TransactionsContract
      */
     public function invalidate(int $id): ApiResponse
     {
-        $payload = Payload::patch('transactions/'.$id.'/invalidate');
+        $payload = Payload::patch(ResourcePath::one('transactions', $id, 'invalidate'));
 
         /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
@@ -241,7 +242,7 @@ final class Transactions implements TransactionsContract
      */
     public function getFile(int $id): ApiFileResponse
     {
-        $payload = Payload::get('transactions/'.$id.'/document_user');
+        $payload = Payload::get(ResourcePath::one('transactions', $id, 'document_user'));
 
         /** @var Response<array{name: string, contents: string}> $response */
         $response = $this->transporter->request($payload);
@@ -277,7 +278,7 @@ final class Transactions implements TransactionsContract
             );
         }
 
-        $payload = Payload::put('transactions/'.$id.'/document_user', $parameters);
+        $payload = Payload::put(ResourcePath::one('transactions', $id, 'document_user'), $parameters);
 
         /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);
@@ -294,7 +295,7 @@ final class Transactions implements TransactionsContract
      */
     public function deleteFile(int $id): ApiResponse
     {
-        $payload = Payload::delete('transactions/'.$id.'/document_user');
+        $payload = Payload::delete(ResourcePath::one('transactions', $id, 'document_user'));
 
         /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */
         $response = $this->transporter->request($payload);

--- a/src/ValueObjects/Transporter/ResourcePath.php
+++ b/src/ValueObjects/Transporter/ResourcePath.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\ValueObjects\Transporter;
+
+/**
+ * Composes e-Financials API resource paths for Payload verbs.
+ *
+ * Keeps HTTP verbs on Payload; this only builds path strings.
+ *
+ * @internal
+ */
+final class ResourcePath
+{
+    private function __construct()
+    {
+        // ..
+    }
+
+    /**
+     * Collection / singleton resource path, e.g. `clients` or `invoice_info`.
+     */
+    public static function collection(string $resource): string
+    {
+        return trim($resource, '/');
+    }
+
+    /**
+     * Single-object path with optional action/file suffixes.
+     *
+     * Examples:
+     * - `clients/1916`
+     * - `sale_invoices/1698/document_user`
+     * - `journals/739/register`
+     */
+    public static function one(string $resource, int|string $id, string ...$segments): string
+    {
+        $parts = [self::collection($resource), (string) $id];
+
+        foreach ($segments as $segment) {
+            $normalized = trim($segment, '/');
+
+            if ($normalized === '') {
+                continue;
+            }
+
+            $parts[] = $normalized;
+        }
+
+        return implode('/', $parts);
+    }
+}

--- a/tests/Arch.php
+++ b/tests/Arch.php
@@ -6,6 +6,7 @@ test('resources')->expect('EFinancialsClient\Resources')->toOnlyUse([
     'EFinancialsClient\Resources\Concerns\Transportable',
     'EFinancialsClient\Responses',
     'EFinancialsClient\ValueObjects\Transporter\Payload',
+    'EFinancialsClient\ValueObjects\Transporter\ResourcePath',
     'EFinancialsClient\ValueObjects\Transporter\Response',
     'DateTime',
     'DateTimeInterface',

--- a/tests/ValueObjects/Transporter/ResourcePath.php
+++ b/tests/ValueObjects/Transporter/ResourcePath.php
@@ -1,0 +1,15 @@
+<?php
+
+use EFinancialsClient\ValueObjects\Transporter\ResourcePath;
+
+it('builds collection paths', function () {
+    expect(ResourcePath::collection('clients'))->toBe('clients')
+        ->and(ResourcePath::collection('/invoice_info/'))->toBe('invoice_info');
+});
+
+it('builds single-object paths with optional suffixes', function () {
+    expect(ResourcePath::one('clients', 1916))->toBe('clients/1916')
+        ->and(ResourcePath::one('sale_invoices', 1698, 'document_user'))->toBe('sale_invoices/1698/document_user')
+        ->and(ResourcePath::one('journals', 739, 'register'))->toBe('journals/739/register')
+        ->and(ResourcePath::one('sale_invoices', '1698', '/pdf_system/'))->toBe('sale_invoices/1698/pdf_system');
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds internal `ResourcePath` helpers for composing API resource paths, and migrates all resources to use them. Payload HTTP verbs (`get` / `post` / `patch` / `put` / `delete`) stay unchanged — no openai-php-style semantic rename.

## Changes

- `ResourcePath::collection('clients')` → `clients`
- `ResourcePath::one('sale_invoices', $id, 'document_user')` → `sale_invoices/{id}/document_user`
- All `src/Resources/*` call sites migrated off string concatenation
- Arch allowlist updated for the new VO
- Unit tests for path composition

## Test plan

- [x] `composer test` (Pint, PHPStan, type coverage, Pest)
- [ ] CI green
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc292-2ac0-79d0-9014-6126f82761ad?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc292-2ac0-79d0-9014-6126f82761ad&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

