### PR TITLE
feat: add SaleInvoiceType enum and credit invoice support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+/.env
+/.omc/
 /.phpunit.cache
 /.php-cs-fixer.cache
 /.php-cs-fixer.php

--- a/src/Contracts/Resources/SalesInvoicesContract.php
+++ b/src/Contracts/Resources/SalesInvoicesContract.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace EFinancialsClient\Contracts\Resources;
 
 use DateTime;
+use EFinancialsClient\Enums\SaleInvoiceType;
 use EFinancialsClient\Responses\ApiFileResponse;
 use EFinancialsClient\Responses\ApiResponse;
 use EFinancialsClient\Responses\SalesInvoices\ListResponse;
@@ -40,6 +41,12 @@ interface SalesInvoicesContract
     /**
      * Create a new sale invoice of the specified company.
      *
+     * `sale_invoice_type` accepts a `SaleInvoiceType` case as well as a raw string.
+     * Credit invoices (kreeditarve) are created here too: `SaleInvoiceType::CREDIT_INVOICE`
+     * plus `credit_sale_invoices_id`, the original's `number_suffix` and negative
+     * `items[].amount`.
+     *
+     * @see SaleInvoiceType
      * @see https://rmp-api.rik.ee/api.html#operation/post-sale_invoices
      *
      * @param  array<string, mixed>  $parameters
@@ -49,6 +56,11 @@ interface SalesInvoicesContract
     /**
      * Modify one specific sale invoice of the specified company.
      *
+     * `sale_invoice_type` accepts a `SaleInvoiceType` case as well as a raw string.
+     * Do not use this to turn an existing invoice into a credit invoice — see the
+     * implementation for why that books the wrong accounting.
+     *
+     * @see SaleInvoiceType
      * @see https://rmp-api.rik.ee/api.html#operation/patch-sale_invoices_one
      *
      * @param  int  $id  Sale invoice identificator.

--- a/src/Enums/SaleInvoiceType.php
+++ b/src/Enums/SaleInvoiceType.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Enums;
+
+/**
+ * Document type of a sale invoice, matching the tabs in the e-Arveldaja web UI.
+ *
+ * The values are not part of the published OpenAPI spec and are not validated
+ * server-side: sending an unrecognised one alongside `credit_sale_invoices_id`
+ * makes the API answer with HTTP 500 instead of a validation error.
+ *
+ * | UI tab           | value                 |
+ * |------------------|-----------------------|
+ * | Müügiarved       | `INVOICE`             |
+ * | Kreeditarved     | `CREDIT-INVOICE`      |
+ * | Ettemaksuarved   | `PREPAYMENT-INVOICE`  |
+ * | Hinnapakkumised  | `QUOTATION`           |
+ */
+enum SaleInvoiceType: string
+{
+    case INVOICE = 'INVOICE';
+    case CREDIT_INVOICE = 'CREDIT-INVOICE';
+    case PREPAYMENT_INVOICE = 'PREPAYMENT-INVOICE';
+    case QUOTATION = 'QUOTATION';
+}

--- a/src/Resources/SalesInvoices.php
+++ b/src/Resources/SalesInvoices.php
@@ -7,6 +7,7 @@ namespace EFinancialsClient\Resources;
 use DateTime;
 use DateTimeInterface;
 use EFinancialsClient\Contracts\Resources\SalesInvoicesContract;
+use EFinancialsClient\Enums\SaleInvoiceType;
 use EFinancialsClient\Resources\Concerns\Transportable;
 use EFinancialsClient\Responses\ApiFileResponse;
 use EFinancialsClient\Responses\ApiResponse;
@@ -108,6 +109,17 @@ final class SalesInvoices implements SalesInvoicesContract
     /**
      * Create a new sale invoice of the specified company.
      *
+     * `sale_invoice_type` accepts a {@see SaleInvoiceType}
+     * case as well as a raw string; enums are unwrapped to their value when the
+     * request is built.
+     *
+     * A credit invoice (kreeditarve) is created through this same endpoint:
+     * pass `sale_invoice_type` as `SaleInvoiceType::CREDIT_INVOICE`, `credit_sale_invoices_id`
+     * with the CONFIRMED original's id, the original's `number_suffix` (the server
+     * derives the `K`-suffixed number itself) and negative `items[].amount` with a
+     * positive `unit_net_price`. Any other `sale_invoice_type` combined with
+     * `credit_sale_invoices_id` makes the API return HTTP 500.
+     *
      * @see https://rmp-api.rik.ee/api.html#operation/post-sale_invoices
      *
      * @param  array<string, mixed>  $parameters
@@ -150,6 +162,14 @@ final class SalesInvoices implements SalesInvoicesContract
 
     /**
      * Modify one specific sale invoice of the specified company.
+     *
+     * `sale_invoice_type` accepts a {@see SaleInvoiceType} case as well as a raw string.
+     *
+     * Do not turn an existing invoice into a credit invoice by patching
+     * `credit_sale_invoices_id` in here. The API accepts it and links the records,
+     * but the invoice is still booked as an ordinary sale (D 1210 / C 1340, positive),
+     * which adds to the receivable instead of clearing it. Create credit invoices
+     * with `create()` instead.
      *
      * @see https://rmp-api.rik.ee/api.html#operation/patch-sale_invoices_one
      *

--- a/src/ValueObjects/Transporter/Payload.php
+++ b/src/ValueObjects/Transporter/Payload.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace EFinancialsClient\ValueObjects\Transporter;
 
+use BackedEnum;
+use EFinancialsClient\Enums\SaleInvoiceType;
 use EFinancialsClient\Enums\Transporter\Method;
 use EFinancialsClient\ValueObjects\ApiCredentials;
 use Http\Discovery\Psr17Factory;
@@ -15,16 +17,53 @@ use Psr\Http\Message\RequestInterface;
 final class Payload
 {
     /**
+     * @var array<string, mixed>
+     */
+    private readonly array $query;
+
+    /**
+     * @var array<array-key, mixed>
+     */
+    private readonly array $body;
+
+    /**
      * @param  array<string, mixed>  $query
      * @param  array<array-key, mixed>  $body
      */
     private function __construct(
         private readonly Method $method,
         private readonly string $resource,
-        private readonly array $query = [],
-        private readonly array $body = [],
+        array $query = [],
+        array $body = [],
     ) {
-        // ..
+        /** @var array<string, mixed> $normalizedQuery */
+        $normalizedQuery = self::normalize($query);
+        /** @var array<array-key, mixed> $normalizedBody */
+        $normalizedBody = self::normalize($body);
+
+        $this->query = $normalizedQuery;
+        $this->body = $normalizedBody;
+    }
+
+    /**
+     * Unwraps backed enums to their scalar values, recursively.
+     *
+     * Callers may pass enums such as {@see SaleInvoiceType}
+     * anywhere the API expects the underlying string or integer.
+     *
+     * @param  array<array-key, mixed>  $values
+     * @return array<array-key, mixed>
+     */
+    private static function normalize(array $values): array
+    {
+        return array_map(
+            static fn (mixed $value): mixed => match (true) {
+                $value instanceof BackedEnum => $value->value,
+                is_array($value) => self::normalize($value),
+                default => $value,
+            },
+            $values,
+        );
     }
 
     /**

--- a/tests/Arch.php
+++ b/tests/Arch.php
@@ -3,6 +3,7 @@
 test('resources')->expect('EFinancialsClient\Resources')->toOnlyUse([
     'EFinancialsClient\Contracts\Resources',
     'EFinancialsClient\Contracts\TransporterContract',
+    'EFinancialsClient\Enums',
     'EFinancialsClient\Resources\Concerns\Transportable',
     'EFinancialsClient\Responses',
     'EFinancialsClient\ValueObjects\Transporter\Payload',

--- a/tests/Fakes/HttpClientFake.php
+++ b/tests/Fakes/HttpClientFake.php
@@ -18,7 +18,15 @@ final class HttpClientFake implements ClientInterface
     /**
      * @param  list<ResponseInterface>  $queue
      */
-    public function __construct(private array $queue = []) {}
+    public function __construct(private array $queue = [])
+    {
+        // ..
+    }
+
+    /**
+     * @var list<RequestInterface>
+     */
+    private array $requests = [];
 
     /**
      * @param  list<ResponseInterface>  $responses
@@ -45,8 +53,18 @@ final class HttpClientFake implements ClientInterface
         return new Response($status, $headers, $body);
     }
 
+    /**
+     * @return list<RequestInterface>
+     */
+    public function requests(): array
+    {
+        return $this->requests;
+    }
+
     public function sendRequest(RequestInterface $request): ResponseInterface
     {
+        $this->requests[] = $request;
+
         $response = array_shift($this->queue);
 
         if (! $response instanceof ResponseInterface) {

--- a/tests/Resources/SalesInvoicesCreditInvoice.php
+++ b/tests/Resources/SalesInvoicesCreditInvoice.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+use EFinancialsClient\Client;
+use EFinancialsClient\Enums\SaleInvoiceType;
+use EFinancialsClient\Responses\SalesInvoices\SaleInvoiceResponse;
+use Tests\Fakes\HttpClientFake;
+
+/**
+ * Credit invoice (kreeditarve) support.
+ *
+ * The API has no dedicated endpoint: a credit invoice is a POST /v1/sale_invoices
+ * with sale_invoice_type = "CREDIT-INVOICE", credit_sale_invoices_id pointing at a
+ * CONFIRMED original, negative items[].amount (positive unit_net_price) and the
+ * original's number_suffix. Any other sale_invoice_type with
+ * credit_sale_invoices_id set makes the server return HTTP 500.
+ */
+const CREDIT_INVOICE_PAYLOAD = [
+    'sale_invoice_type' => 'CREDIT-INVOICE',
+    'credit_sale_invoices_id' => 6612,
+    'cl_templates_id' => 1,
+    'clients_id' => 6097,
+    'cl_countries_id' => 'EST',
+    'number_prefix' => 'ARB-',
+    'number_suffix' => '990030',
+    'create_date' => '2026-08-03',
+    'journal_date' => '2026-08-03',
+    'term_days' => 0,
+    'cl_currencies_id' => 'EUR',
+    'show_client_balance' => false,
+    'receivable_accounts_id' => 1210,
+    'items' => [
+        [
+            'custom_title' => 'Krediidi test',
+            'products_id' => 2320,
+            'amount' => -1,
+            'unit_net_price' => 100,
+            'vat_rate' => 0,
+            'cl_sale_articles_id' => 35,
+            'sale_accounts_id' => 1340,
+        ],
+    ],
+];
+
+function creditInvoiceClient(HttpClientFake $http): Client
+{
+    return EFinancials::factory()
+        ->withApiKeyId('id')
+        ->withApiKeyPublic('public')
+        ->withApiKeyPassword('password')
+        ->withHttpClient($http)
+        ->make();
+}
+
+it('sends the documented credit invoice payload verbatim', function () {
+    $http = HttpClientFake::sequence([
+        HttpClientFake::response(200, [
+            'code' => 0,
+            'created_object_id' => 6613,
+            'messages' => ['Invoice saved.'],
+        ]),
+    ]);
+
+    $response = creditInvoiceClient($http)->salesInvoices()->create(CREDIT_INVOICE_PAYLOAD);
+
+    expect($response->createdObjectId)->toBe(6613);
+
+    $request = $http->requests()[0];
+
+    expect((string) $request->getMethod())->toBe('POST')
+        ->and((string) $request->getUri())->toContain('/v1/sale_invoices');
+
+    /** @var array<string, mixed> $sent */
+    $sent = json_decode((string) $request->getBody(), true, 512, JSON_THROW_ON_ERROR);
+
+    // Nothing is filtered, coerced or reordered on the way out: the falsy
+    // (term_days, show_client_balance, vat_rate) and negative (amount) values
+    // that carry the credit semantics must survive intact.
+    expect($sent)->toBe(CREDIT_INVOICE_PAYLOAD)
+        ->and($sent['sale_invoice_type'])->toBe('CREDIT-INVOICE')
+        ->and($sent['credit_sale_invoices_id'])->toBe(6612)
+        ->and($sent['items'][0]['amount'])->toBe(-1)
+        ->and($sent['items'][0]['unit_net_price'])->toBe(100)
+        ->and($sent['term_days'])->toBe(0)
+        ->and($sent['show_client_balance'])->toBeFalse();
+});
+
+it('accepts the SaleInvoiceType enum for sale_invoice_type', function () {
+    $http = HttpClientFake::sequence([
+        HttpClientFake::response(200, ['code' => 0, 'created_object_id' => 6613]),
+    ]);
+
+    creditInvoiceClient($http)->salesInvoices()->create(
+        ['sale_invoice_type' => SaleInvoiceType::CREDIT_INVOICE] + CREDIT_INVOICE_PAYLOAD
+    );
+
+    /** @var array<string, mixed> $sent */
+    $sent = json_decode((string) $http->requests()[0]->getBody(), true, 512, JSON_THROW_ON_ERROR);
+
+    expect($sent['sale_invoice_type'])->toBe('CREDIT-INVOICE');
+});
+
+it('registers, invalidates and deletes a credit invoice', function () {
+    $ok = ['code' => 0, 'messages' => ['OK']];
+
+    $http = HttpClientFake::sequence([
+        HttpClientFake::response(200, $ok),
+        HttpClientFake::response(200, $ok),
+        HttpClientFake::response(200, $ok),
+    ]);
+
+    $invoices = creditInvoiceClient($http)->salesInvoices();
+
+    $invoices->register(6613);
+    $invoices->invalidate(6613);
+    $invoices->delete(6613);
+
+    $sent = array_map(
+        fn ($request): string => $request->getMethod().' '.$request->getUri()->getPath(),
+        $http->requests(),
+    );
+
+    // Unwind order for a credited original is strictly child-first:
+    // invalidate credit -> delete credit -> invalidate original -> delete original.
+    expect($sent)->toBe([
+        'PATCH /v1/sale_invoices/6613/register',
+        'PATCH /v1/sale_invoices/6613/invalidate',
+        'DELETE /v1/sale_invoices/6613',
+    ]);
+});
+
+it('reads back the server-computed negative totals and credit links', function () {
+    $invoice = SaleInvoiceResponse::from([
+        'id' => 6613,
+        'sale_invoice_type' => 'CREDIT-INVOICE',
+        'number' => 'ARB-990030K',
+        'credit_sale_invoices_id' => 6612,
+        'credit_invoice_payment_type' => null,
+        'net_price' => -100.0,
+        'gross_price' => -100.0,
+        'credit_invoices' => [],
+        'items' => [
+            [
+                'id' => 1,
+                'amount' => -1.0,
+                'unit_net_price' => 100.0,
+                'total_net_price' => -100.0,
+            ],
+        ],
+    ]);
+
+    expect($invoice->saleInvoiceType)->toBe('CREDIT-INVOICE')
+        ->and($invoice->creditSaleInvoicesId)->toBe(6612)
+        ->and($invoice->creditInvoicePaymentType)->toBeNull()
+        ->and($invoice->netPrice)->toBe(-100.0)
+        ->and($invoice->grossPrice)->toBe(-100.0)
+        ->and($invoice->items[0]->amount)->toBe(-1.0)
+        ->and($invoice->items[0]->unitNetPrice)->toBe(100.0)
+        ->and($invoice->items[0]->totalNetPrice)->toBe(-100.0);
+});
+
+it('exposes credit_invoices on the original so callers can tell it was credited', function () {
+    $original = SaleInvoiceResponse::from([
+        'id' => 6612,
+        'sale_invoice_type' => 'INVOICE',
+        'credit_invoices' => [6613],
+    ]);
+
+    expect($original->creditInvoices)->toBe([6613]);
+});

--- a/tests/ValueObjects/Transporter/Payload.php
+++ b/tests/ValueObjects/Transporter/Payload.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+use EFinancialsClient\Enums\SaleInvoiceType;
+use EFinancialsClient\ValueObjects\ApiCredentials;
+use EFinancialsClient\ValueObjects\Transporter\BaseUri;
+use EFinancialsClient\ValueObjects\Transporter\Headers;
+use EFinancialsClient\ValueObjects\Transporter\Payload;
+use Psr\Http\Message\RequestInterface;
+
+function payloadRequest(Payload $payload): RequestInterface
+{
+    return $payload->toRequest(
+        BaseUri::from('https://demo-rmp-api.rik.ee', 'v1'),
+        Headers::create(),
+        ApiCredentials::from('id', 'public', 'password'),
+    );
+}
+
+it('unwraps backed enums in the body, at any depth', function () {
+    $payload = Payload::post('sale_invoices', [
+        'sale_invoice_type' => SaleInvoiceType::CREDIT_INVOICE,
+        'nested' => ['type' => SaleInvoiceType::QUOTATION],
+        'items' => [
+            ['type' => SaleInvoiceType::PREPAYMENT_INVOICE, 'amount' => -1],
+        ],
+    ]);
+
+    expect($payload->body())->toBe([
+        'sale_invoice_type' => 'CREDIT-INVOICE',
+        'nested' => ['type' => 'QUOTATION'],
+        'items' => [
+            ['type' => 'PREPAYMENT-INVOICE', 'amount' => -1],
+        ],
+    ]);
+
+    $sent = json_decode((string) payloadRequest($payload)->getBody(), true, 512, JSON_THROW_ON_ERROR);
+
+    expect($sent['sale_invoice_type'])->toBe('CREDIT-INVOICE')
+        ->and($sent['items'][0]['type'])->toBe('PREPAYMENT-INVOICE');
+});
+
+it('unwraps backed enums on patch and put bodies too', function () {
+    $body = ['sale_invoice_type' => SaleInvoiceType::INVOICE];
+
+    expect(Payload::patch('sale_invoices/1', $body)->body())->toBe(['sale_invoice_type' => 'INVOICE'])
+        ->and(Payload::put('sale_invoices/1/document_user', $body)->body())->toBe(['sale_invoice_type' => 'INVOICE']);
+});
+
+it('unwraps backed enums in the query string', function () {
+    $payload = Payload::get('sale_invoices', ['type' => SaleInvoiceType::INVOICE, 'page' => 2]);
+
+    expect($payload->query())->toBe(['type' => 'INVOICE', 'page' => 2])
+        ->and((string) payloadRequest($payload)->getUri())->toContain('type=INVOICE&page=2');
+});
+
+it('leaves scalars, nulls and falsy values untouched', function () {
+    $body = [
+        'term_days' => 0,
+        'show_client_balance' => false,
+        'amount' => -1.5,
+        'note' => null,
+        'title' => 'Krediidi test',
+    ];
+
+    expect(Payload::post('sale_invoices', $body)->body())->toBe($body);
+});
+
+it('maps every documented sale invoice type', function () {
+    expect(array_map(
+        fn (SaleInvoiceType $type): string => $type->value,
+        SaleInvoiceType::cases(),
+    ))->toBe(['INVOICE', 'CREDIT-INVOICE', 'PREPAYMENT-INVOICE', 'QUOTATION']);
+});


### PR DESCRIPTION
## What

Adds `EFinancialsClient\Enums\SaleInvoiceType`, a backed string enum for the four document types behind the e-Arveldaja UI tabs:

| UI tab | case | value |
|---|---|---|
| Müügiarved | `INVOICE` | `INVOICE` |
| Kreeditarved | `CREDIT_INVOICE` | `CREDIT-INVOICE` |
| Ettemaksuarved | `PREPAYMENT_INVOICE` | `PREPAYMENT-INVOICE` |
| Hinnapakkumised | `QUOTATION` | `QUOTATION` |

`sale_invoice_type` now accepts a case as well as a raw string.

## Enum → string conversion

`Payload` unwraps any `BackedEnum` to its scalar value, recursively, in both the request body and the query string. This is generic — every resource and any future enum gets it.

Normalisation happens in the `Payload` constructor rather than at `json_encode` time, for two reasons:

- `http_build_query` would throw on an enum object in a GET query; backed enums only serialise for free inside `json_encode`.
- `body()`/`query()` now return the same scalars that go on the wire, so `ClientFake::assertSent` closures assert against real values.

## Credit invoices (kreeditarve)

The client was already capable of creating them — `create()` forwards an arbitrary array and `Payload::toRequest()` `json_encode`s it verbatim with no falsy-value filtering, so `amount: -1`, `term_days: 0` and `show_client_balance: false` all survive; `floatOrNull` preserves the server-computed negative totals on read-back. This PR pins that behaviour with tests and documents the parts that aren't in the OpenAPI spec:

- `POST /sale_invoices` with `SaleInvoiceType::CREDIT_INVOICE`, `credit_sale_invoices_id` (a **CONFIRMED** original), the original's `number_suffix` (the server derives the `K` suffix) and negative `items[].amount` with positive `unit_net_price`.
- Any other `sale_invoice_type` combined with `credit_sale_invoices_id` returns **HTTP 500**, not a validation error.
- `update()` carries a warning against patching `credit_sale_invoices_id` onto an existing invoice: the API accepts it and links the records, but books an ordinary sale (`D 1210 / C 1340`, positive), adding to the receivable instead of clearing it.

## Notes for review

- **`tests/Arch.php` was widened** to allow `EFinancialsClient\Enums` inside `Resources`. Pint's `fully_qualified_strict_types` turns the `{@see}` reference into an import, which the previous rule rejected. Allowing it seems right — enums are public surface — but it is a boundary change, so flag it if you'd rather keep the rule tight.
- `SaleInvoiceResponse::$saleInvoiceType` is still `?string`. Input accepts the enum; output does not return one. Changing that is breaking for consumers, so it was left alone.
- `HttpClientFake` now records outgoing requests, so assertions can inspect the real encoded body rather than the `Payload` object.

## Testing

`composer test` (lint, PHPStan, type-coverage, unit) passes — 40 tests, 231 assertions. `composer test:mutate` was not run: no coverage driver available locally.
