### PR TITLE
fix: unblock devcontainer test runner and type spec query enums

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,9 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/php
 {
 	"name": "PHP",
-	"image": "mcr.microsoft.com/devcontainers/php:1-8.2",
+	// Pest 5 / PHPUnit 13 (require-dev) need PHP >= 8.4, even though the
+	// library itself supports ^8.2 for consumers.
+	"image": "mcr.microsoft.com/devcontainers/php:1-8.4",
 
 	"customizations": {
 		"vscode": {
@@ -28,6 +30,9 @@
 
 	"postCreateCommand": {
 		"xdebug-fix": "echo \"xdebug.log = ${containerWorkspaceFolder}/xdebug.log\" | sudo tee -a /usr/local/etc/php/conf.d/xdebug.ini > /dev/null",
+		// PHPStan exhausts the 128M default and crashes; CI does not hit this
+		// because setup-php runs with memory_limit=-1.
+		"memory-limit": "echo \"memory_limit = 1G\" | sudo tee /usr/local/etc/php/conf.d/zz-memory-limit.ini > /dev/null",
 		"dependencies": "composer install"
 	}
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,8 +2,6 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/php
 {
 	"name": "PHP",
-	// Pest 5 / PHPUnit 13 (require-dev) need PHP >= 8.4, even though the
-	// library itself supports ^8.2 for consumers.
 	"image": "mcr.microsoft.com/devcontainers/php:1-8.4",
 
 	"customizations": {
@@ -30,8 +28,6 @@
 
 	"postCreateCommand": {
 		"xdebug-fix": "echo \"xdebug.log = ${containerWorkspaceFolder}/xdebug.log\" | sudo tee -a /usr/local/etc/php/conf.d/xdebug.ini > /dev/null",
-		// PHPStan exhausts the 128M default and crashes; CI does not hit this
-		// because setup-php runs with memory_limit=-1.
 		"memory-limit": "echo \"memory_limit = 1G\" | sudo tee /usr/local/etc/php/conf.d/zz-memory-limit.ini > /dev/null",
 		"dependencies": "composer install"
 	}

--- a/src/Contracts/Resources/PurchaseInvoicesContract.php
+++ b/src/Contracts/Resources/PurchaseInvoicesContract.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace EFinancialsClient\Contracts\Resources;
 
 use DateTime;
+use EFinancialsClient\Enums\InvoiceStatus;
+use EFinancialsClient\Enums\PaymentStatus;
 use EFinancialsClient\Responses\ApiFileResponse;
 use EFinancialsClient\Responses\ApiResponse;
 use EFinancialsClient\Responses\PurchaseInvoices\ListResponse;
@@ -21,11 +23,11 @@ interface PurchaseInvoicesContract
      * @param  DateTime|string  $modifiedSince  Return only objects modified since provided timestamp.
      * @param  DateTime|string  $startDate  Object created on given date or later.
      * @param  DateTime|string  $endDate  Object created on given date or before.
-     * @param  string  $status  Object status.
-     * @param  string  $paymentStatus  Object payment status.
+     * @param  InvoiceStatus|string  $status  Object status.
+     * @param  PaymentStatus|string  $paymentStatus  Object payment status.
      * @param  int|null  $clientsId  Supplier identificator.
      */
-    public function all(int $page = 1, DateTime|string $modifiedSince = '', DateTime|string $startDate = '', DateTime|string $endDate = '', string $status = '', string $paymentStatus = '', ?int $clientsId = null): ListResponse;
+    public function all(int $page = 1, DateTime|string $modifiedSince = '', DateTime|string $startDate = '', DateTime|string $endDate = '', InvoiceStatus|string $status = '', PaymentStatus|string $paymentStatus = '', ?int $clientsId = null): ListResponse;
 
     /**
      * Retrieve one specific purchase invoice of the specified company.

--- a/src/Contracts/Resources/SalesInvoicesContract.php
+++ b/src/Contracts/Resources/SalesInvoicesContract.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace EFinancialsClient\Contracts\Resources;
 
 use DateTime;
+use EFinancialsClient\Enums\InvoiceStatus;
+use EFinancialsClient\Enums\PaymentStatus;
 use EFinancialsClient\Enums\SaleInvoiceType;
 use EFinancialsClient\Responses\ApiFileResponse;
 use EFinancialsClient\Responses\ApiResponse;
@@ -23,11 +25,11 @@ interface SalesInvoicesContract
      * @param  DateTime|string  $modifiedSince  Return only objects modified since provided timestamp.
      * @param  DateTime|string  $startDate  Object revenue date on given date or later.
      * @param  DateTime|string  $endDate  Object revenue date on given date or before.
-     * @param  string  $status  Object status.
-     * @param  string  $paymentStatus  Object payment status.
+     * @param  InvoiceStatus|string  $status  Object status.
+     * @param  PaymentStatus|string  $paymentStatus  Object payment status.
      * @param  int|null  $clientsId  Customer identificator.
      */
-    public function all(int $page = 1, DateTime|string $modifiedSince = '', DateTime|string $startDate = '', DateTime|string $endDate = '', string $status = '', string $paymentStatus = '', ?int $clientsId = null): ListResponse;
+    public function all(int $page = 1, DateTime|string $modifiedSince = '', DateTime|string $startDate = '', DateTime|string $endDate = '', InvoiceStatus|string $status = '', PaymentStatus|string $paymentStatus = '', ?int $clientsId = null): ListResponse;
 
     /**
      * Retrieve one specific sale invoice of the specified company.

--- a/src/Contracts/Resources/TransactionsContract.php
+++ b/src/Contracts/Resources/TransactionsContract.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace EFinancialsClient\Contracts\Resources;
 
 use DateTime;
+use EFinancialsClient\Enums\TransactionStatus;
+use EFinancialsClient\Enums\TransactionType;
 use EFinancialsClient\Responses\ApiFileResponse;
 use EFinancialsClient\Responses\ApiResponse;
 use EFinancialsClient\Responses\Transactions\ListResponse;
@@ -21,11 +23,11 @@ interface TransactionsContract
      * @param  DateTime|string  $modifiedSince  Return only objects modified since provided timestamp.
      * @param  DateTime|string  $startDate  Date on given date or later.
      * @param  DateTime|string  $endDate  Date on given date or before.
-     * @param  string  $status  Object status.
-     * @param  string  $type  Object type.
+     * @param  TransactionStatus|string  $status  Object status.
+     * @param  TransactionType|string  $type  Object type.
      * @param  int|null  $clientsId  Customer identificator.
      */
-    public function all(int $page = 1, DateTime|string $modifiedSince = '', DateTime|string $startDate = '', DateTime|string $endDate = '', string $status = '', string $type = '', ?int $clientsId = null): ListResponse;
+    public function all(int $page = 1, DateTime|string $modifiedSince = '', DateTime|string $startDate = '', DateTime|string $endDate = '', TransactionStatus|string $status = '', TransactionType|string $type = '', ?int $clientsId = null): ListResponse;
 
     /**
      * Retrieve one specific transaction of the specified company.
@@ -70,7 +72,7 @@ interface TransactionsContract
      * @see https://rmp-api.rik.ee/api.html#operation/patch-transactions_one_register
      *
      * @param  int  $id  Transaction identificator.
-     * @param  array<int, mixed>  $distributions  Optional transaction distribution rows.
+     * @param  array<int, array<string, mixed>>  $distributions  Optional transaction distribution rows.
      */
     public function register(int $id, array $distributions = []): ApiResponse;
 

--- a/src/Enums/InvoiceStatus.php
+++ b/src/Enums/InvoiceStatus.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Enums;
+
+/**
+ * Status of a sale or purchase invoice, as accepted by the `status`
+ * query parameter.
+ *
+ * Note this differs from {@see TransactionStatus}, which additionally
+ * has a `VOID` case.
+ *
+ * @see https://rmp-api.rik.ee/api.html#operation/get-sale_invoices
+ * @see https://rmp-api.rik.ee/api.html#operation/get-purchase_invoices
+ */
+enum InvoiceStatus: string
+{
+    case PROJECT = 'PROJECT';
+    case CONFIRMED = 'CONFIRMED';
+}

--- a/src/Enums/PaymentStatus.php
+++ b/src/Enums/PaymentStatus.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Enums;
+
+/**
+ * Payment status of a sale or purchase invoice, as accepted by the
+ * `payment_status` query parameter.
+ *
+ * @see https://rmp-api.rik.ee/api.html#operation/get-sale_invoices
+ * @see https://rmp-api.rik.ee/api.html#operation/get-purchase_invoices
+ */
+enum PaymentStatus: string
+{
+    case PAID = 'PAID';
+    case PARTIALLY_PAID = 'PARTIALLY_PAID';
+    case NOT_PAID = 'NOT_PAID';
+}

--- a/src/Enums/TransactionStatus.php
+++ b/src/Enums/TransactionStatus.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Enums;
+
+/**
+ * Status of a transaction, as accepted by the `status` query parameter.
+ *
+ * Note this differs from {@see InvoiceStatus}, which has no `VOID` case.
+ *
+ * @see https://rmp-api.rik.ee/api.html#operation/get-transactions
+ */
+enum TransactionStatus: string
+{
+    case PROJECT = 'PROJECT';
+    case CONFIRMED = 'CONFIRMED';
+    case VOID = 'VOID';
+}

--- a/src/Enums/TransactionType.php
+++ b/src/Enums/TransactionType.php
@@ -8,14 +8,13 @@ namespace EFinancialsClient\Enums;
  * Type of a transaction, as accepted by the `type` query parameter.
  *
  * The spec describes the underlying field only as
- * "type - incoming payment/outgoing payment/settlement" and does not say
- * which of those `C` and `D` map to, so the cases are named after their
- * literal values rather than asserting a meaning.
+ * "type - incoming payment/outgoing payment/settlement" without saying
+ * which value is which; `C` is credit and `D` is debit.
  *
  * @see https://rmp-api.rik.ee/api.html#operation/get-transactions
  */
 enum TransactionType: string
 {
-    case C = 'C';
-    case D = 'D';
+    case CREDIT = 'C';
+    case DEBIT = 'D';
 }

--- a/src/Enums/TransactionType.php
+++ b/src/Enums/TransactionType.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EFinancialsClient\Enums;
+
+/**
+ * Type of a transaction, as accepted by the `type` query parameter.
+ *
+ * @see https://rmp-api.rik.ee/api.html#operation/get-transactions
+ */
+enum TransactionType: string
+{
+    case CREDIT = 'C';
+    case DEBIT = 'D';
+}

--- a/src/Enums/TransactionType.php
+++ b/src/Enums/TransactionType.php
@@ -7,10 +7,15 @@ namespace EFinancialsClient\Enums;
 /**
  * Type of a transaction, as accepted by the `type` query parameter.
  *
+ * The spec describes the underlying field only as
+ * "type - incoming payment/outgoing payment/settlement" and does not say
+ * which of those `C` and `D` map to, so the cases are named after their
+ * literal values rather than asserting a meaning.
+ *
  * @see https://rmp-api.rik.ee/api.html#operation/get-transactions
  */
 enum TransactionType: string
 {
-    case CREDIT = 'C';
-    case DEBIT = 'D';
+    case C = 'C';
+    case D = 'D';
 }

--- a/src/Resources/PurchaseInvoices.php
+++ b/src/Resources/PurchaseInvoices.php
@@ -7,6 +7,8 @@ namespace EFinancialsClient\Resources;
 use DateTime;
 use DateTimeInterface;
 use EFinancialsClient\Contracts\Resources\PurchaseInvoicesContract;
+use EFinancialsClient\Enums\InvoiceStatus;
+use EFinancialsClient\Enums\PaymentStatus;
 use EFinancialsClient\Resources\Concerns\Transportable;
 use EFinancialsClient\Responses\ApiFileResponse;
 use EFinancialsClient\Responses\ApiResponse;
@@ -30,8 +32,8 @@ final class PurchaseInvoices implements PurchaseInvoicesContract
      * @param  DateTime|string  $modifiedSince  Return only objects modified since provided timestamp.
      * @param  DateTime|string  $startDate  Object created on given date or later.
      * @param  DateTime|string  $endDate  Object created on given date or before.
-     * @param  string  $status  Object status.
-     * @param  string  $paymentStatus  Object payment status.
+     * @param  InvoiceStatus|string  $status  Object status.
+     * @param  PaymentStatus|string  $paymentStatus  Object payment status.
      * @param  int|null  $clientsId  Supplier identificator.
      */
     public function all(
@@ -39,8 +41,8 @@ final class PurchaseInvoices implements PurchaseInvoicesContract
         DateTime|string $modifiedSince = '',
         DateTime|string $startDate = '',
         DateTime|string $endDate = '',
-        string $status = '',
-        string $paymentStatus = '',
+        InvoiceStatus|string $status = '',
+        PaymentStatus|string $paymentStatus = '',
         ?int $clientsId = null,
     ): ListResponse {
         $query = [];

--- a/src/Resources/SalesInvoices.php
+++ b/src/Resources/SalesInvoices.php
@@ -7,6 +7,8 @@ namespace EFinancialsClient\Resources;
 use DateTime;
 use DateTimeInterface;
 use EFinancialsClient\Contracts\Resources\SalesInvoicesContract;
+use EFinancialsClient\Enums\InvoiceStatus;
+use EFinancialsClient\Enums\PaymentStatus;
 use EFinancialsClient\Enums\SaleInvoiceType;
 use EFinancialsClient\Resources\Concerns\Transportable;
 use EFinancialsClient\Responses\ApiFileResponse;
@@ -32,8 +34,8 @@ final class SalesInvoices implements SalesInvoicesContract
      * @param  DateTime|string  $modifiedSince  Return only objects modified since provided timestamp.
      * @param  DateTime|string  $startDate  Object revenue date on given date or later.
      * @param  DateTime|string  $endDate  Object revenue date on given date or before.
-     * @param  string  $status  Object status.
-     * @param  string  $paymentStatus  Object payment status.
+     * @param  InvoiceStatus|string  $status  Object status.
+     * @param  PaymentStatus|string  $paymentStatus  Object payment status.
      * @param  int|null  $clientsId  Customer identificator.
      */
     public function all(
@@ -41,8 +43,8 @@ final class SalesInvoices implements SalesInvoicesContract
         DateTime|string $modifiedSince = '',
         DateTime|string $startDate = '',
         DateTime|string $endDate = '',
-        string $status = '',
-        string $paymentStatus = '',
+        InvoiceStatus|string $status = '',
+        PaymentStatus|string $paymentStatus = '',
         ?int $clientsId = null,
     ): ListResponse {
         $query = [];

--- a/src/Resources/Transactions.php
+++ b/src/Resources/Transactions.php
@@ -7,6 +7,8 @@ namespace EFinancialsClient\Resources;
 use DateTime;
 use DateTimeInterface;
 use EFinancialsClient\Contracts\Resources\TransactionsContract;
+use EFinancialsClient\Enums\TransactionStatus;
+use EFinancialsClient\Enums\TransactionType;
 use EFinancialsClient\Resources\Concerns\Transportable;
 use EFinancialsClient\Responses\ApiFileResponse;
 use EFinancialsClient\Responses\ApiResponse;
@@ -30,8 +32,8 @@ final class Transactions implements TransactionsContract
      * @param  DateTime|string  $modifiedSince  Return only objects modified since provided timestamp.
      * @param  DateTime|string  $startDate  Date on given date or later.
      * @param  DateTime|string  $endDate  Date on given date or before.
-     * @param  string  $status  Object status.
-     * @param  string  $type  Object type.
+     * @param  TransactionStatus|string  $status  Object status.
+     * @param  TransactionType|string  $type  Object type.
      * @param  int|null  $clientsId  Customer identificator.
      */
     public function all(
@@ -39,8 +41,8 @@ final class Transactions implements TransactionsContract
         DateTime|string $modifiedSince = '',
         DateTime|string $startDate = '',
         DateTime|string $endDate = '',
-        string $status = '',
-        string $type = '',
+        TransactionStatus|string $status = '',
+        TransactionType|string $type = '',
         ?int $clientsId = null,
     ): ListResponse {
         $query = [];
@@ -204,10 +206,30 @@ final class Transactions implements TransactionsContract
      * @see https://rmp-api.rik.ee/api.html#operation/patch-transactions_one_register
      *
      * @param  int  $id  Transaction identificator.
-     * @param  array<int, mixed>  $distributions  Optional transaction distribution rows.
+     * @param  array<int, array<string, mixed>>  $distributions  Optional transaction distribution rows.
      */
     public function register(int $id, array $distributions = []): ApiResponse
     {
+        foreach ($distributions as $index => $distribution) {
+            $missingRequiredParameters = array_diff_key(
+                array_flip(
+                    [
+                        'related_table',
+                        'amount',
+                    ]
+                ),
+                $distribution
+            );
+
+            if (count($missingRequiredParameters) !== 0) {
+                $missingKeys = implode(', ', array_keys($missingRequiredParameters));
+
+                throw new InvalidArgumentException(
+                    "Distribution row $index is missing required parameter(s): $missingKeys"
+                );
+            }
+        }
+
         $payload = Payload::patch(ResourcePath::one('transactions', $id, 'register'), $distributions);
 
         /** @var Response<array{code: int, messages?: array<int, string>, created_object_id?: int|null}> $response */

--- a/tests/Resources/QueryEnums.php
+++ b/tests/Resources/QueryEnums.php
@@ -26,7 +26,7 @@ it('unwraps transaction enums into the query string', function () {
 
     $fake->transactions()->all(
         status: TransactionStatus::CONFIRMED,
-        type: TransactionType::D,
+        type: TransactionType::DEBIT,
     );
 
     $fake->assertSent('transactions', fn (Payload $payload): bool => $payload->query() === [

--- a/tests/Resources/QueryEnums.php
+++ b/tests/Resources/QueryEnums.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+use EFinancialsClient\Enums\InvoiceStatus;
+use EFinancialsClient\Enums\PaymentStatus;
+use EFinancialsClient\Enums\TransactionStatus;
+use EFinancialsClient\Enums\TransactionType;
+use EFinancialsClient\Responses\PurchaseInvoices\ListResponse as PurchaseInvoicesListResponse;
+use EFinancialsClient\Responses\SalesInvoices\ListResponse as SalesInvoicesListResponse;
+use EFinancialsClient\Responses\Transactions\ListResponse as TransactionsListResponse;
+use EFinancialsClient\Testing\ClientFake;
+use EFinancialsClient\ValueObjects\Transporter\Payload;
+
+it('matches the enum cases declared in the OpenAPI spec', function () {
+    expect(array_column(TransactionStatus::cases(), 'value'))->toBe(['PROJECT', 'CONFIRMED', 'VOID'])
+        ->and(array_column(TransactionType::cases(), 'value'))->toBe(['C', 'D'])
+        // The invoice status enum deliberately has no VOID case; the spec lists
+        // only PROJECT and CONFIRMED for sale/purchase invoices.
+        ->and(array_column(InvoiceStatus::cases(), 'value'))->toBe(['PROJECT', 'CONFIRMED'])
+        ->and(array_column(PaymentStatus::cases(), 'value'))->toBe(['PAID', 'PARTIALLY_PAID', 'NOT_PAID']);
+});
+
+it('unwraps transaction enums into the query string', function () {
+    $fake = new ClientFake([TransactionsListResponse::fake()]);
+
+    $fake->transactions()->all(
+        status: TransactionStatus::CONFIRMED,
+        type: TransactionType::DEBIT,
+    );
+
+    $fake->assertSent('transactions', fn (Payload $payload): bool => $payload->query() === [
+        'status' => 'CONFIRMED',
+        'type' => 'D',
+    ]);
+});
+
+it('unwraps sale invoice enums into the query string', function () {
+    $fake = new ClientFake([SalesInvoicesListResponse::fake()]);
+
+    $fake->salesInvoices()->all(
+        status: InvoiceStatus::PROJECT,
+        paymentStatus: PaymentStatus::NOT_PAID,
+    );
+
+    $fake->assertSent('sale_invoices', fn (Payload $payload): bool => $payload->query() === [
+        'status' => 'PROJECT',
+        'payment_status' => 'NOT_PAID',
+    ]);
+});
+
+it('unwraps purchase invoice enums into the query string', function () {
+    $fake = new ClientFake([PurchaseInvoicesListResponse::fake()]);
+
+    $fake->purchaseInvoices()->all(
+        status: InvoiceStatus::CONFIRMED,
+        paymentStatus: PaymentStatus::PARTIALLY_PAID,
+    );
+
+    $fake->assertSent('purchase_invoices', fn (Payload $payload): bool => $payload->query() === [
+        'status' => 'CONFIRMED',
+        'payment_status' => 'PARTIALLY_PAID',
+    ]);
+});
+
+it('still accepts raw strings for the same parameters', function () {
+    $fake = new ClientFake([TransactionsListResponse::fake()]);
+
+    $fake->transactions()->all(status: 'CONFIRMED', type: 'D');
+
+    $fake->assertSent('transactions', fn (Payload $payload): bool => $payload->query() === [
+        'status' => 'CONFIRMED',
+        'type' => 'D',
+    ]);
+});
+
+it('omits the enum parameters entirely when they are not supplied', function () {
+    $fake = new ClientFake([TransactionsListResponse::fake()]);
+
+    $fake->transactions()->all();
+
+    $fake->assertSent('transactions', fn (Payload $payload): bool => $payload->query() === []);
+});

--- a/tests/Resources/QueryEnums.php
+++ b/tests/Resources/QueryEnums.php
@@ -15,8 +15,6 @@ use EFinancialsClient\ValueObjects\Transporter\Payload;
 it('matches the enum cases declared in the OpenAPI spec', function () {
     expect(array_column(TransactionStatus::cases(), 'value'))->toBe(['PROJECT', 'CONFIRMED', 'VOID'])
         ->and(array_column(TransactionType::cases(), 'value'))->toBe(['C', 'D'])
-        // The invoice status enum deliberately has no VOID case; the spec lists
-        // only PROJECT and CONFIRMED for sale/purchase invoices.
         ->and(array_column(InvoiceStatus::cases(), 'value'))->toBe(['PROJECT', 'CONFIRMED'])
         ->and(array_column(PaymentStatus::cases(), 'value'))->toBe(['PAID', 'PARTIALLY_PAID', 'NOT_PAID']);
 });

--- a/tests/Resources/QueryEnums.php
+++ b/tests/Resources/QueryEnums.php
@@ -26,7 +26,7 @@ it('unwraps transaction enums into the query string', function () {
 
     $fake->transactions()->all(
         status: TransactionStatus::CONFIRMED,
-        type: TransactionType::DEBIT,
+        type: TransactionType::D,
     );
 
     $fake->assertSent('transactions', fn (Payload $payload): bool => $payload->query() === [

--- a/tests/Resources/TransactionDistributions.php
+++ b/tests/Resources/TransactionDistributions.php
@@ -50,8 +50,6 @@ it('sends no body when no distributions are supplied', function () {
 
     $fake->transactions()->register(2672);
 
-    // The spec does not mark the register requestBody as required, so an
-    // empty distribution list must send no body at all.
     $fake->assertSent(
         'transactions/2672/register',
         fn (Payload $payload): bool => $payload->body() === []

--- a/tests/Resources/TransactionDistributions.php
+++ b/tests/Resources/TransactionDistributions.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+use EFinancialsClient\Responses\ApiResponse;
+use EFinancialsClient\Testing\ClientFake;
+use EFinancialsClient\ValueObjects\Transporter\Payload;
+
+it('rejects a distribution row missing required parameters', function () {
+    $fake = new ClientFake([ApiResponse::fake()]);
+
+    expect(fn () => $fake->transactions()->register(2672, [
+        ['related_table' => 'accounts', 'amount' => 10.0],
+        ['related_table' => 'accounts'],
+    ]))->toThrow(
+        InvalidArgumentException::class,
+        'Distribution row 1 is missing required parameter(s): amount'
+    );
+});
+
+it('names every missing key in the offending row', function () {
+    $fake = new ClientFake([ApiResponse::fake()]);
+
+    expect(fn () => $fake->transactions()->register(2672, [
+        ['related_id' => 1010],
+    ]))->toThrow(
+        InvalidArgumentException::class,
+        'Distribution row 0 is missing required parameter(s): related_table, amount'
+    );
+});
+
+it('sends valid distribution rows as the request body', function () {
+    $fake = new ClientFake([ApiResponse::fake()]);
+
+    $fake->transactions()->register(2672, [
+        ['related_table' => 'accounts', 'related_id' => 1010, 'amount' => 2348.32],
+    ]);
+
+    $fake->assertSent(
+        'transactions/2672/register',
+        fn (Payload $payload): bool => $payload->method()->value === 'PATCH'
+            && $payload->body() === [
+                ['related_table' => 'accounts', 'related_id' => 1010, 'amount' => 2348.32],
+            ]
+    );
+});
+
+it('sends no body when no distributions are supplied', function () {
+    $fake = new ClientFake([ApiResponse::fake()]);
+
+    $fake->transactions()->register(2672);
+
+    // The spec does not mark the register requestBody as required, so an
+    // empty distribution list must send no body at all.
+    $fake->assertSent(
+        'transactions/2672/register',
+        fn (Payload $payload): bool => $payload->body() === []
+    );
+});


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

Follows an audit of the client against [the published OpenAPI spec](https://demo-rmp-api.rik.ee/openapi.yaml). Endpoint coverage turned out to be complete — all 78 operations are implemented and the 15 Contract interfaces declare exactly the 78 methods the Resource classes expose. These are the typing gaps the audit surfaced, plus the container fix needed to verify any of it.

**Unblock the test runner (prerequisite).** The devcontainer ran PHP 8.2 while `pestphp/pest v5` and `phpunit 13` both require `^8.4`, so the suite could not start at all (`Runner/Version.php` parse error). CI's matrix is 8.4/8.5, so 8.2 was never a tested configuration. Also adds a `memory_limit = 1G` php.ini drop-in — PHPStan crashes on the container's 128M default, which CI never hits because `setup-php` uses `-1`.

**Type the six `enum:` query parameters.** Adds `TransactionStatus`, `TransactionType`, `InvoiceStatus` and `PaymentStatus`, accepted as unions alongside the existing strings in `Transactions::all()`, `SalesInvoices::all()` and `PurchaseInvoices::all()`. `Payload::normalize()` already unwraps backed enums, so no transporter change was needed and existing string callers keep working.

Two deliberate choices worth a reviewer's eye:

- `InvoiceStatus` omits `VOID`. The spec lists `PROJECT|CONFIRMED|VOID` for transactions but only `PROJECT|CONFIRMED` for sale/purchase invoices, so they cannot share one type.
- Response DTOs keep `?string`. No response schema declares an enum, so typing them would exceed the spec and throw on any unlisted server value — and unlike the request side, that cannot be softened with a union.
- `TransactionType::CREDIT`/`DEBIT` are named from domain knowledge, not the spec: the schema describes the field only as "type - incoming payment/outgoing payment/settlement". Backed values are `C`/`D`, so the wire format is unchanged.

**Validate transaction distribution rows.** `Transactions::register()` accepted `array<int, mixed>` and never checked the `related_table`/`amount` that `TransactionsDistribution` marks required. Adds a per-row guard naming the offending index, and narrows the docblock to `array<int, array<string, mixed>>`. An empty list still sends no body — the spec does not mark that `requestBody` as required.

**Verification:** `composer test` exits 0 (lint, phpstan, type-coverage, 50 tests / 246 assertions, up from 40). `composer test:mutate` scores 30.04%, above the `--min=20` gate.

**Not included:** the audit also flagged that `Invoices::update()` requires all 5 keys on a PATCH. That is left alone deliberately — the spec reuses the full `InvoiceSeries` schema (with its `required:` block) as the PATCH body, and all 8 `update()` methods share the same convention, so changing one would create an inconsistency. Whether the server actually rejects a partial PATCH is an open empirical question.
